### PR TITLE
Fix dynreg delete bugs

### DIFF
--- a/openid-connect-server/src/main/java/org/mitre/openid/connect/web/ClientDynamicRegistrationEndpoint.java
+++ b/openid-connect-server/src/main/java/org/mitre/openid/connect/web/ClientDynamicRegistrationEndpoint.java
@@ -306,21 +306,11 @@ public class ClientDynamicRegistrationEndpoint {
 
 			clientService.deleteClient(client);
 
-			// we return the token that we got in
-			OAuth2AuthenticationDetails details = (OAuth2AuthenticationDetails) auth.getDetails();
-			OAuth2AccessTokenEntity token = tokenService.readAccessToken(details.getTokenValue());
-
-			// TODO: urlencode the client id for safety?
-			RegisteredClient registered = new RegisteredClient(client, token.getValue(), config.getIssuer() + "register/" + client.getClientId());
-
 			// send it all out to the view
 			m.addAttribute("client", client);
-			m.addAttribute("code", HttpStatus.OK); // http 200
-			//m.addAttribute("token", token);
-			// TODO: urlencode the client id for safety?
-			//m.addAttribute("uri", config.getIssuer() + "register/" + client.getClientId());
+			m.addAttribute("code", HttpStatus.NO_CONTENT); // http 204
 
-			return "clientInformationResponseView";
+			return "httpCodeView";
 		} else {
 			// client mismatch
 			logger.error("readClientConfiguration failed, client ID mismatch: "


### PR DESCRIPTION
1. Delete sequence was failing because it deleted the client and _then_ tried to look up its details (because it no longer existed.)
2. Align with dynreg return code 204 (don't return content, just an empty body on success)
