### PR TITLE
Allow Spring to instantiate DefaultUserInfoUserDetailsService via DI

### DIFF
--- a/openid-connect-server/src/main/java/org/mitre/openid/connect/service/impl/DefaultUserInfoUserDetailsService.java
+++ b/openid-connect-server/src/main/java/org/mitre/openid/connect/service/impl/DefaultUserInfoUserDetailsService.java
@@ -52,6 +52,7 @@ public class DefaultUserInfoUserDetailsService implements UserDetailsService {
 	 * 
 	 * @param repository the UserInfoRepository to set
 	 */
+	@Autowired
 	public DefaultUserInfoUserDetailsService(UserInfoRepository repository) {
 		this.repository = repository;
 	}


### PR DESCRIPTION
https://github.com/mitreid-connect/OpenID-Connect-Java-Spring-Server/commit/a7f2e605fad3e85e2949368ea27d960251941853 adds a new constructor for `DefaultUserInfoUserDetailsService` ...

... and the combination of **having _some_ constructor** and not having an empty one prevents Spring from instantiating the bean automatically on deployment.

Great to see that unit tests are a-coming  (and ironic, I guess, that this one broke the build).
