### PR TITLE
Enforces minimum Java version 1.6 on the openid-connect-server project.

### DIFF
--- a/openid-connect-server/pom.xml
+++ b/openid-connect-server/pom.xml
@@ -25,6 +25,18 @@
     	<version>1.1.0-SNAPSHOT</version>
     	<relativePath>..</relativePath>
     </parent>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>${java-version}</source>
+                    <target>${java-version}</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
     <dependencies>
 		<dependency>
 			<groupId>org.mitre</groupId>


### PR DESCRIPTION
addresses issue #514.
