### PR TITLE
Add support for Resource Owner Password Credentials Grant

### DIFF
--- a/openid-connect-server-webapp/src/main/webapp/WEB-INF/application-context.xml
+++ b/openid-connect-server-webapp/src/main/webapp/WEB-INF/application-context.xml
@@ -156,6 +156,7 @@
 		<oauth:implicit />
 		<oauth:refresh-token/>
 		<oauth:client-credentials/>
+		<oauth:password/>
 		<oauth:custom-grant token-granter-ref="chainedTokenGranter" />
 		<oauth:custom-grant token-granter-ref="jwtAssertionTokenGranter" />
 


### PR DESCRIPTION
For "first-party" clients (i.e. with a high-level of trust between the resource owner and the client) the OAuth2 "Resource Owner Password Credentials Grant" may be used to exchange credentials for an access token.

Please consider adding support for this grant type.
