### PR TITLE
an alternative token cleanup mechanism designed to maintain a very compa...

### DIFF
--- a/openid-connect-common/src/main/java/org/mitre/oauth2/model/AuthenticationHolderEntity.java
+++ b/openid-connect-common/src/main/java/org/mitre/oauth2/model/AuthenticationHolderEntity.java
@@ -33,7 +33,8 @@ import org.springframework.security.oauth2.provider.OAuth2Authentication;
 @Entity
 @Table(name = "authentication_holder")
 @NamedQueries ({
-	@NamedQuery(name = "AuthenticationHolderEntity.getByAuthentication", query = "select a from AuthenticationHolderEntity a where a.authentication = :authentication")
+	@NamedQuery(name = "AuthenticationHolderEntity.getByAuthentication", query = "select a from AuthenticationHolderEntity a where a.authentication = :authentication"),
+	@NamedQuery(name = "AuthenticationHolderEntity.getUnusedAuthenticationHolders", query = "select a from AuthenticationHolderEntity a where a.id not in (select t.authenticationHolderId from OAuth2AccessTokenEntity t) and a.id not in (select r.authenticationHolderId from OAuth2RefreshTokenEntity r)")
 })
 public class AuthenticationHolderEntity {
 

--- a/openid-connect-common/src/main/java/org/mitre/oauth2/model/OAuth2AccessTokenEntity.java
+++ b/openid-connect-common/src/main/java/org/mitre/oauth2/model/OAuth2AccessTokenEntity.java
@@ -58,6 +58,7 @@ import com.nimbusds.jwt.JWTParser;
 @Table(name = "access_token")
 @NamedQueries({
 	@NamedQuery(name = "OAuth2AccessTokenEntity.getAll", query = "select a from OAuth2AccessTokenEntity a"),
+	@NamedQuery(name = "OAuth2AccessTokenEntity.getAllExpiredByDate", query = "select a from OAuth2AccessTokenEntity a where a.expiration <= :date"),
 	@NamedQuery(name = "OAuth2AccessTokenEntity.getByRefreshToken", query = "select a from OAuth2AccessTokenEntity a where a.refreshToken = :refreshToken"),
 	@NamedQuery(name = "OAuth2AccessTokenEntity.getByClient", query = "select a from OAuth2AccessTokenEntity a where a.client = :client"),
 	@NamedQuery(name = "OAuth2AccessTokenEntity.getByAuthentication", query = "select a from OAuth2AccessTokenEntity a where a.authenticationHolder.authentication = :authentication"),

--- a/openid-connect-common/src/main/java/org/mitre/oauth2/model/OAuth2RefreshTokenEntity.java
+++ b/openid-connect-common/src/main/java/org/mitre/oauth2/model/OAuth2RefreshTokenEntity.java
@@ -50,6 +50,7 @@ import com.nimbusds.jwt.JWTParser;
 @Table(name = "refresh_token")
 @NamedQueries({
 	@NamedQuery(name = "OAuth2RefreshTokenEntity.getAll", query = "select r from OAuth2RefreshTokenEntity r"),
+	@NamedQuery(name = "OAuth2RefreshTokenEntity.getAllExpiredByDate", query = "select r from OAuth2RefreshTokenEntity r where r.expiration <= :date"),
 	@NamedQuery(name = "OAuth2RefreshTokenEntity.getByClient", query = "select r from OAuth2RefreshTokenEntity r where r.client = :client"),
 	@NamedQuery(name = "OAuth2RefreshTokenEntity.getByTokenValue", query = "select r from OAuth2RefreshTokenEntity r where r.value = :tokenValue"),
 	@NamedQuery(name = "OAuth2RefreshTokenEntity.getByAuthentication", query = "select r from OAuth2RefreshTokenEntity r where r.authenticationHolder.authentication = :authentication")

--- a/openid-connect-common/src/main/java/org/mitre/oauth2/repository/AuthenticationHolderRepository.java
+++ b/openid-connect-common/src/main/java/org/mitre/oauth2/repository/AuthenticationHolderRepository.java
@@ -16,6 +16,8 @@
  ******************************************************************************/
 package org.mitre.oauth2.repository;
 
+import java.util.List;
+
 import org.mitre.oauth2.model.AuthenticationHolderEntity;
 import org.springframework.security.oauth2.provider.OAuth2Authentication;
 
@@ -30,5 +32,8 @@ public interface AuthenticationHolderRepository {
 	public void remove(AuthenticationHolderEntity a);
 
 	public AuthenticationHolderEntity save(AuthenticationHolderEntity a);
+	
+	public List<AuthenticationHolderEntity> getOrphanedAuthenticationHolders();
+
 
 }

--- a/openid-connect-common/src/main/java/org/mitre/oauth2/repository/OAuth2TokenRepository.java
+++ b/openid-connect-common/src/main/java/org/mitre/oauth2/repository/OAuth2TokenRepository.java
@@ -57,5 +57,9 @@ public interface OAuth2TokenRepository {
 	public Set<OAuth2AccessTokenEntity> getAllAccessTokens();
 
 	public Set<OAuth2RefreshTokenEntity> getAllRefreshTokens();
+	
+	public Set<OAuth2AccessTokenEntity> getAllExpiredAccessTokens();
+
+	public Set<OAuth2RefreshTokenEntity> getAllExpiredRefreshTokens();
 
 }

--- a/openid-connect-server/src/main/java/org/mitre/oauth2/repository/impl/JpaAuthenticationHolderRepository.java
+++ b/openid-connect-server/src/main/java/org/mitre/oauth2/repository/impl/JpaAuthenticationHolderRepository.java
@@ -16,6 +16,8 @@
  ******************************************************************************/
 package org.mitre.oauth2.repository.impl;
 
+import java.util.List;
+
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.persistence.TypedQuery;
@@ -31,6 +33,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class JpaAuthenticationHolderRepository implements AuthenticationHolderRepository {
 
+	private static final int MAXEXPIREDRESULTS = 1000;	
+	
 	@PersistenceContext
 	private EntityManager manager;
 
@@ -72,6 +76,15 @@ public class JpaAuthenticationHolderRepository implements AuthenticationHolderRe
 	@Transactional
 	public AuthenticationHolderEntity save(AuthenticationHolderEntity a) {
 		return JpaUtil.saveOrUpdate(a.getId(), manager, a);
+	}
+	
+	@Override
+	@Transactional
+	public List<AuthenticationHolderEntity> getOrphanedAuthenticationHolders() {
+		TypedQuery<AuthenticationHolderEntity> query = manager.createNamedQuery("AuthenticationHolderEntity.getUnusedAuthenticationHolders", AuthenticationHolderEntity.class);
+		query.setMaxResults(MAXEXPIREDRESULTS);
+		List<AuthenticationHolderEntity> unusedAuthenticationHolders = query.getResultList();
+		return unusedAuthenticationHolders;
 	}
 
 }

--- a/openid-connect-server/src/main/java/org/mitre/oauth2/repository/impl/JpaOAuth2TokenRepository.java
+++ b/openid-connect-server/src/main/java/org/mitre/oauth2/repository/impl/JpaOAuth2TokenRepository.java
@@ -16,6 +16,7 @@
  ******************************************************************************/
 package org.mitre.oauth2.repository.impl;
 
+import java.util.Date;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -35,6 +36,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 public class JpaOAuth2TokenRepository implements OAuth2TokenRepository {
+
+	private static final int MAXEXPIREDRESULTS = 1000;
 
 	@PersistenceContext
 	private EntityManager manager;
@@ -177,6 +180,22 @@ public class JpaOAuth2TokenRepository implements OAuth2TokenRepository {
 		queryA.setParameter("idToken", idToken);
 		List<OAuth2AccessTokenEntity> accessTokens = queryA.getResultList();
 		return JpaUtil.getSingleResult(accessTokens);
+	}
+	
+	@Override
+	public Set<OAuth2AccessTokenEntity> getAllExpiredAccessTokens() {
+		TypedQuery<OAuth2AccessTokenEntity> query = manager.createNamedQuery("OAuth2AccessTokenEntity.getAllExpiredByDate", OAuth2AccessTokenEntity.class);
+		query.setParameter("date", new Date());
+		query.setMaxResults(MAXEXPIREDRESULTS);
+		return new LinkedHashSet<OAuth2AccessTokenEntity>(query.getResultList());
+	}
+
+	@Override
+	public Set<OAuth2RefreshTokenEntity> getAllExpiredRefreshTokens() {
+		TypedQuery<OAuth2RefreshTokenEntity> query = manager.createNamedQuery("OAuth2RefreshTokenEntity.getAllExpiredByDate", OAuth2RefreshTokenEntity.class);
+		query.setParameter("date", new Date());
+		query.setMaxResults(MAXEXPIREDRESULTS);
+		return new LinkedHashSet<OAuth2RefreshTokenEntity>(query.getResultList());
 	}
 
 }


### PR DESCRIPTION
This is an alternative token cleanup mechanism designed to maintain a very compact memory footprint while performing cleanup in consecutive runs of the cleanup thread. This serves to address OutOfMemoryException issues of the original token cleanup mechanism when process is under load. Also, added cleanup of the authentication_holder table.
