### PR TITLE
Make introspection endpoint access authorization pluggable.

### DIFF
--- a/openid-connect-common/src/main/java/org/mitre/oauth2/service/IntrospectionAuthorizer.java
+++ b/openid-connect-common/src/main/java/org/mitre/oauth2/service/IntrospectionAuthorizer.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright 2014 The MITRE Corporation
+ *   and the MIT Kerberos and Internet Trust Consortium
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+package org.mitre.oauth2.service;
+
+import java.util.Set;
+
+import org.springframework.security.oauth2.provider.ClientDetails;
+
+/**
+ * Strategy interface used for authorizing token introspection.
+ */
+public interface IntrospectionAuthorizer {
+
+	/**
+	 * @param authClient the authenticated client wanting to perform token introspection
+	 * @param tokenClient the client the token was issued to
+	 * @param tokenScope the scope associated with the token
+	 * @return {@code true} in case introspection is permitted; {@code false} otherwise
+	 */
+	boolean isIntrospectionPermitted(ClientDetails authClient, ClientDetails tokenClient, Set<String> tokenScope);
+
+}

--- a/openid-connect-server/src/main/java/org/mitre/oauth2/service/impl/DefaultIntrospectionAuthorizer.java
+++ b/openid-connect-server/src/main/java/org/mitre/oauth2/service/impl/DefaultIntrospectionAuthorizer.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright 2014 The MITRE Corporation
+ *   and the MIT Kerberos and Internet Trust Consortium
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+package org.mitre.oauth2.service.impl;
+
+import java.util.Set;
+
+import org.mitre.oauth2.service.IntrospectionAuthorizer;
+import org.mitre.oauth2.service.SystemScopeService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.oauth2.provider.ClientDetails;
+import org.springframework.stereotype.Service;
+
+@Service
+public class DefaultIntrospectionAuthorizer implements IntrospectionAuthorizer {
+
+	@Autowired
+	private SystemScopeService scopeService;
+
+	@Override
+	public boolean isIntrospectionPermitted(ClientDetails authClient,
+			ClientDetails tokenClient, Set<String> tokenScope) {
+		// permit introspection if it's the same client that the token was
+		// issued to, or it at least has all the scopes the token was issued
+		// with
+		return authClient.getClientId().equals(tokenClient.getClientId())
+				|| scopeService.scopesMatch(authClient.getScope(), tokenScope);
+	}
+
+}

--- a/openid-connect-server/src/test/java/org/mitre/oauth2/service/impl/TestDefaultIntrospectionAuthorizer.java
+++ b/openid-connect-server/src/test/java/org/mitre/oauth2/service/impl/TestDefaultIntrospectionAuthorizer.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2014 by Netcetera AG.
+ * All rights reserved.
+ *
+ * The copyright to the computer program(s) herein is the property of Netcetera AG, Switzerland.
+ * The program(s) may be used and/or copied only with the written permission of Netcetera AG or
+ * in accordance with the terms and conditions stipulated in the agreement/contract under which 
+ * the program(s) have been supplied.
+ */
+package org.mitre.oauth2.service.impl;
+
+import java.util.Set;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mitre.oauth2.service.SystemScopeService;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.security.oauth2.provider.ClientDetails;
+
+import static com.google.common.collect.Sets.newHashSet;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TestDefaultIntrospectionAuthorizer {
+
+	@InjectMocks
+	private DefaultIntrospectionAuthorizer introspectionPermitter;
+
+	@Mock
+	private SystemScopeService scopeService;
+
+	@Test
+	public void shouldPermitIntrospectionToSameClientTheTokenWasIssuedTo() {
+
+		// given
+		String sameClient = "same";
+
+		// when
+		boolean permitted = introspectionPermitter.isIntrospectionPermitted(
+				clientWithId(sameClient), clientWithId(sameClient),
+				scope("scope"));
+
+		// then
+		assertThat(permitted, is(true));
+	}
+
+	@Test
+	public void shouldPermitIntrospectionToDifferentClientIfScopesMatch() {
+
+		// given
+		String authClient = "auth";
+		String tokenClient = "token";
+		Set<String> authScope = scope("scope1", "scope2", "scope3");
+		Set<String> tokenScope = scope("scope1", "scope2");
+		given(scopeService.scopesMatch(authScope, tokenScope)).willReturn(true);
+
+		// when
+		boolean permitted = introspectionPermitter.isIntrospectionPermitted(
+				clientWithIdAndScope(authClient, authScope),
+				clientWithId(tokenClient), tokenScope);
+
+		// then
+		assertThat(permitted, is(true));
+	}
+
+	@Test
+	public void shouldNotPermitIntrospectionToDifferentClientIfScopesDontMatch() {
+
+		// given
+		String authClient = "auth";
+		String tokenClient = "token";
+		Set<String> authScope = scope("scope1", "scope2");
+		Set<String> tokenScope = scope("scope1", "scope2", "scope3");
+		given(scopeService.scopesMatch(authScope, tokenScope))
+				.willReturn(false);
+
+		// when
+		boolean permitted = introspectionPermitter.isIntrospectionPermitted(
+				clientWithIdAndScope(authClient, authScope),
+				clientWithId(tokenClient), tokenScope);
+
+		// then
+		assertThat(permitted, is(false));
+	}
+
+	private ClientDetails clientWithId(String clientId) {
+		ClientDetails client = mock(ClientDetails.class);
+		given(client.getClientId()).willReturn(clientId);
+		return client;
+	}
+
+	private ClientDetails clientWithIdAndScope(String clientId,
+			Set<String> scope) {
+		ClientDetails client = clientWithId(clientId);
+		given(client.getScope()).willReturn(scope);
+		return client;
+	}
+
+	private Set<String> scope(String... scopeItems) {
+		return newHashSet(scopeItems);
+	}
+}


### PR DESCRIPTION
This allows us to plug in our own access authorization logic to use the introspection endpoint (see https://github.com/mitreid-connect/OpenID-Connect-Java-Spring-Server/issues/590).

We can do so by having our own implementation of the IntrospectionAuthorizer interface and marking it as the primary bean for autowiring (i.e. using the @Primary annotation).
