### PR TITLE
Use return value from TokenEnhancer.enhance

### DIFF
--- a/openid-connect-server/src/main/java/org/mitre/oauth2/service/impl/DefaultOAuth2ProviderTokenService.java
+++ b/openid-connect-server/src/main/java/org/mitre/oauth2/service/impl/DefaultOAuth2ProviderTokenService.java
@@ -195,8 +195,7 @@ public class DefaultOAuth2ProviderTokenService implements OAuth2TokenEntityServi
 				token.setRefreshToken(refreshToken);
 			}
 
-			tokenEnhancer.enhance(token, authentication);
-
+			token = (OAuth2AccessTokenEntity) tokenEnhancer.enhance(token, authentication);
 			tokenRepository.saveAccessToken(token);
 
 			//Add approved site reference, if any


### PR DESCRIPTION
The enhancer is supposed to return a new token -- but `DefaultOAuth2ProviderTokenService` was expecting (relying on) mutations instead. Ditto for the tests. Which made it hard for me to extend these classes for my own purposes.

This PR is just a one-line fix + test updates.
