### PR TITLE
Fix delete client when deleting list item

### DIFF
--- a/openid-connect-server-webapp/src/main/webapp/resources/js/admin.js
+++ b/openid-connect-server-webapp/src/main/webapp/resources/js/admin.js
@@ -88,6 +88,7 @@ var ListWidgetChildView = Backbone.View.extend({
     
     deleteItem:function (e) {
     	e.preventDefault();
+    	e.stopImmediatePropagation();
         //this.$el.tooltip('delete');
         
         this.model.destroy({         
@@ -137,6 +138,7 @@ var ListWidgetView = Backbone.View.extend({
 
     events:{
         "click .btn-add":"addItem",
+        "blur input": "addItem",
         "keypress":function (e) {
         	// trap the enter key
             if (e.which == 13) {
@@ -161,7 +163,11 @@ var ListWidgetView = Backbone.View.extend({
     addItem:function(e) {
     	e.preventDefault();
 
-    	var input_value = $("input", this.el).val().trim();
+        var input_value = $("input", this.el).val().trim();
+
+        if (input_value === ""){
+           return;
+        }
 
         var model;
 


### PR DESCRIPTION
There's a problem with the way nested Backbone views are implementing events:
- The "client registration" view listens for "click .btn-delete" in order to run `deleteClient`
- The list of contact emails view listens for "click .btn-delete" in order to run `deleteItem`

... but this means when a user deletes a contact, the entire client gets deleted, too (or at least, an alert pops up asking to confirm client deletion). Yikes!

This PR is a minimal fix. But the right solution would involve _not_ matching all internal button-clicks from the client registration view. (I would have taken a stab at that, but then I saw the code duplication across `dynreg.js`, `client.js`, and `admin.js`, and couldn't understand what was going on.)

Also corrects a usability bug in the list controller, which lets you "leave text hanging" in the `redirect_uri`  or `contacts` inputs if you forget to click `+`.
