### PR TITLE
Validate HMAC-signed ID tokens in the client filter

### DIFF
--- a/openid-connect-common/src/main/java/org/mitre/jwt/signer/service/impl/SymmetricCacheService.java
+++ b/openid-connect-common/src/main/java/org/mitre/jwt/signer/service/impl/SymmetricCacheService.java
@@ -98,7 +98,7 @@ public class SymmetricCacheService {
 
 				String id = "SYMMETRIC-KEY";
 
-				JWK jwk = new OctetSequenceKey(new Base64URL(key), Use.SIGNATURE, null, id, null, null, null);
+				JWK jwk = new OctetSequenceKey(Base64URL.encode(key), Use.SIGNATURE, null, id, null, null, null);
 				Map<String, JWK> keys = ImmutableMap.of(id, jwk);
 				JwtSigningAndValidationService service = new DefaultJwtSigningAndValidationService(keys);
 


### PR DESCRIPTION
I am trying to integrate the client filter into an application using [Auth0](https://auth0.com/) as an OP. After coding around some minor spec compliance issues (which I have reported to them), I'm now working on ID token validation. The only signing algorithm they seem to support is HS256.

Adding support for HMAC validation was fairly straight-forward now with the presence of `SymmetricCacheService`. However, that class has somewhat-surprising behavior: it assumes that client secrets (as represented in `ClientDetailsEntity`) are not Base64 encoded. It seems like `ClientDetailsEntity` needs some way to indicate that the secret is already encoded.
