### PR TITLE
Update pom.xml

### DIFF
--- a/openid-connect-common/pom.xml
+++ b/openid-connect-common/pom.xml
@@ -60,9 +60,9 @@
         </dependency>
     	<dependency>
       		<groupId>org.springframework.security.oauth</groupId>
- 		 	<version>2.0.0.M2</version>
+ 		 <version>2.0.2.RELEASE</version>
       		<artifactId>spring-security-oauth2</artifactId>
-		</dependency>
+	</dependency>
         <dependency>
         	<groupId>com.nimbusds</groupId>
         	<artifactId>nimbus-jose-jwt</artifactId>


### PR DESCRIPTION
spring-security-oauth2 has been released since the 2.0.0.M2 milestone was posted, and that version has been pulled from the global repos.
