### PR TITLE
Fix IE8/9 issue where form elements don't display

### DIFF
--- a/openid-connect-server-webapp/src/main/webapp/resources/css/mitreid-connect.css
+++ b/openid-connect-server-webapp/src/main/webapp/resources/css/mitreid-connect.css
@@ -139,7 +139,7 @@ h1,label {
   .input-prepend.input-block-level > input {
     display: table; /* table-cell is not working well in Chrome for small widths */
   }
-}		  }
+}
 
 .input-append.input-block-level > input {
   border-right: 0;


### PR DESCRIPTION
The MitreID CSS overrides boostrap's use of "display: table-cell" in some input fields to just "display: table". The causes these fields to not be editable in IE8/9.

There is a comment on the relevant line in the CSS explaining that this is a workaround for a Chrome display issue, so I've moved the relevant CSS into a chrome-only block. This is tested in IE8/9/Chrome/FF.
