### PR TITLE
Omit uninformative error_description

### DIFF
--- a/openid-connect-server/src/main/java/org/mitre/oauth2/token/StructuredScopeAwareOAuth2RequestValidator.java
+++ b/openid-connect-server/src/main/java/org/mitre/oauth2/token/StructuredScopeAwareOAuth2RequestValidator.java
@@ -49,7 +49,7 @@ public class StructuredScopeAwareOAuth2RequestValidator implements OAuth2Request
 		if (requestedScopes != null && !requestedScopes.isEmpty()) {
 			if (clientScopes != null && !clientScopes.isEmpty()) {
 				if (!scopeService.scopesMatch(clientScopes, requestedScopes)) {
-					throw new InvalidScopeException("Invalid scope", clientScopes);
+					throw new InvalidScopeException(null, clientScopes);
 				}
 			}
 		}


### PR DESCRIPTION
This is an API usability thing: when a client displays an error to the user, how does the client know what text to show on the screen?

rfc6749 says:

```
 error_description
         OPTIONAL.  Human-readable ASCII [USASCII] text providing
         additional information, used to assist the client developer in
         understanding the error that occurred.
```

If there's no "additional information" to convey, the `error_description` shouldn't be populated.  Leaving the message null will cause `error_description` to be omitted [in Spring secoauth](https://github.com/spring-projects/spring-security-oauth/blob/master/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/common/exceptions/OAuth2Exception.java#L176).

(This was an issue for us when trying to automatically decide what message to display on the screen in case of errors.)