### PR TITLE
Use the same "options" for token exchange that were needed for authorization request

### DIFF
--- a/openid-connect-client/src/main/java/org/mitre/openid/connect/client/OIDCAuthenticationFilter.java
+++ b/openid-connect-client/src/main/java/org/mitre/openid/connect/client/OIDCAuthenticationFilter.java
@@ -302,6 +302,9 @@ public class OIDCAuthenticationFilter extends AbstractAuthenticationProcessingFi
 		final RegisteredClient clientConfig = clients.getClientConfiguration(serverConfig);
 
 		MultiValueMap<String, String> form = new LinkedMultiValueMap<String, String>();
+
+		form.setAll(authOptions.getOptions(serverConfig, clientConfig, null));
+
 		form.add("grant_type", "authorization_code");
 		form.add("code", authorizationCode);
 


### PR DESCRIPTION
With OpenAM server, several requests require an additional "realm" parameter. This 1-line change updates the token exchange request, to pass the same options that had been prepared for the initial authorization request to the OP.