### PR TITLE
Add X-Frame-Options header

### DIFF
--- a/openid-connect-server-webapp/src/main/webapp/WEB-INF/user-context.xml
+++ b/openid-connect-server-webapp/src/main/webapp/WEB-INF/user-context.xml
@@ -48,6 +48,9 @@
 		<security:logout logout-url="/logout" />
 		<security:anonymous />
 		<security:expression-handler ref="oauthWebExpressionHandler" />
+		<security:headers>
+			<security:frame-options policy="DENY" />
+		</security:headers>
 	</security:http>	
 
 </beans>


### PR DESCRIPTION
Fixes #762

I've also removed the HTTP security configuration for `/login**` because it seems unnecessary. I'd be happy to add it back if it makes sense.