### PR TITLE
Remove Spring Security <http> block for /login**

### DIFF
--- a/openid-connect-server-webapp/src/main/webapp/WEB-INF/user-context.xml
+++ b/openid-connect-server-webapp/src/main/webapp/WEB-INF/user-context.xml
@@ -37,10 +37,6 @@
 		
 	<mvc:view-controller path="/login" view-name="login" />
 
-	<security:http pattern="/login**" use-expressions="true" entry-point-ref="http403EntryPoint">
-		<security:intercept-url pattern="/login**" access="permitAll"/>	
-	</security:http>
-	
 	<security:http disable-url-rewriting="true" use-expressions="true"> 
 		<security:form-login login-page="/login" authentication-failure-url="/login?error=failure" authentication-success-handler-ref="authenticationTimeStamper" />
 		<security:intercept-url pattern="/**" access="permitAll" />


### PR DESCRIPTION
There is `<security:intercept-url pattern="/**" access="permitAll" />` in the bottom HTTP block, so the login page should never be behind authentication.