### PR TITLE
Add empty <relativePath> to avoid Maven warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
 		<groupId>org.sonatype.oss</groupId>
 		<artifactId>oss-parent</artifactId>
 		<version>9</version>
+		<relativePath></relativePath>
 	</parent>
 	<licenses>
 		<license>


### PR DESCRIPTION
Occurs when using a Git submodule in overlay project.

````
[WARNING] Some problems were encountered while building the effective model for org.mitre:openid-connect-common:jar:1.2.0-SNAPSHOT
[WARNING] 'parent.relativePath' of POM org.mitre:openid-connect-parent:1.2.0-SNAPSHOT (…/OpenID-Connect-Java-Spring-Server/pom.xml) points at …:…-overlay instead of org.sonatype.oss:oss-parent, please verify your project structure @ org.mitre:openid-connect-parent:1.2.0-SNAPSHOT, …/OpenID-Connect-Java-Spring-Server/pom.xml, line 26, column 10
```