### PR TITLE
Improve Spring Security dependency management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -311,7 +311,29 @@
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.security</groupId>
+				<artifactId>spring-security-config</artifactId>
+				<version>${spring.security.version}</version>
+				<exclusions>
+					<exclusion>
+						<groupId>org.springframework</groupId>
+						<artifactId>*</artifactId>
+					</exclusion>
+				</exclusions>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.security</groupId>
 				<artifactId>spring-security-taglibs</artifactId>
+				<version>${spring.security.version}</version>
+				<exclusions>
+					<exclusion>
+						<groupId>org.springframework</groupId>
+						<artifactId>*</artifactId>
+					</exclusion>
+				</exclusions>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.security</groupId>
+				<artifactId>spring-security-web</artifactId>
 				<version>${spring.security.version}</version>
 				<exclusions>
 					<exclusion>


### PR DESCRIPTION
For Spring Security `-config` and `-web` dependencies, that get drawn in by Spring Security OAuth2:

```
% mvn dependency:tree
…
[INFO] +- org.springframework.security:spring-security-core:jar:3.2.5.RELEASE:compile
…
[INFO] +- org.springframework.security.oauth:spring-security-oauth2:jar:2.0.3.RELEASE:compile
[INFO] |  +- org.springframework.security:spring-security-config:jar:3.2.3.RELEASE:compile
[INFO] |  +- org.springframework.security:spring-security-web:jar:3.2.3.RELEASE:compile
…
````