### PR TITLE
use default system scopes if none specified when creating a new client

### DIFF
--- a/openid-connect-server/src/main/java/org/mitre/oauth2/service/impl/DefaultOAuth2ClientDetailsEntityService.java
+++ b/openid-connect-server/src/main/java/org/mitre/oauth2/service/impl/DefaultOAuth2ClientDetailsEntityService.java
@@ -135,6 +135,10 @@ public class DefaultOAuth2ClientDetailsEntityService implements ClientDetailsEnt
 		// check the sector URI
 		checkSectorIdentifierUri(client);
 
+		// if no scopes were specified, use default system scopes
+		if(! client.isScoped()){
+			client.setScope(scopeService.toStrings(scopeService.getDefaults()));
+		}
 
 		ensureNoReservedScopes(client);
 


### PR DESCRIPTION
The API documentation says that:
> If scope is omitted or null, all system scopes marked as "default" will be assigned to the client

However, I faced a bug where it is not doing this. I am not really sure where this logic (to use defaults) should be put, but I though the DefaultOAuth2ClientDetailsEntityService is the right place.

Am I missing something here? Is it really implemented before? If not, do you think this is the right place or should it be in ClientAPI.apiAddClient?