### PR TITLE
OIDCAuthenticationFilter: Make authenticationSignerService optional so

### DIFF
--- a/openid-connect-client/src/main/java/org/mitre/openid/connect/client/OIDCAuthenticationFilter.java
+++ b/openid-connect-client/src/main/java/org/mitre/openid/connect/client/OIDCAuthenticationFilter.java
@@ -110,7 +110,7 @@ public class OIDCAuthenticationFilter extends AbstractAuthenticationProcessingFi
 	private SymmetricKeyJWTValidatorCacheService symmetricCacheService;
 
 	// signer based on keypair for this client (for outgoing auth requests)
-	@Autowired
+	@Autowired(required=false)
 	private JWTSigningAndValidationService authenticationSignerService;
 
 

--- a/openid-connect-client/src/main/java/org/mitre/openid/connect/client/OIDCAuthenticationProvider.java
+++ b/openid-connect-client/src/main/java/org/mitre/openid/connect/client/OIDCAuthenticationProvider.java
@@ -100,6 +100,13 @@ public class OIDCAuthenticationProvider implements AuthenticationProvider {
 	}
 
 	/**
+	 * @param userInfoFetcher
+	 */
+	public void setUserInfoFetcher(UserInfoFetcher userInfoFetcher) {
+		this.userInfoFetcher = userInfoFetcher;
+	}
+
+	/**
 	 * @param authoritiesMapper
 	 */
 	public void setAuthoritiesMapper(OIDCAuthoritiesMapper authoritiesMapper) {

--- a/openid-connect-client/src/main/java/org/mitre/openid/connect/client/UserInfoFetcher.java
+++ b/openid-connect-client/src/main/java/org/mitre/openid/connect/client/UserInfoFetcher.java
@@ -109,7 +109,7 @@ public class UserInfoFetcher {
 
 				JsonObject userInfoJson = new JsonParser().parse(userInfoString).getAsJsonObject();
 
-				UserInfo userInfo = DefaultUserInfo.fromJson(userInfoJson);
+				UserInfo userInfo = fromJson(userInfoJson);
 
 				return userInfo;
 			} else {
@@ -123,4 +123,7 @@ public class UserInfoFetcher {
 
 	}
 
+	protected UserInfo fromJson(JsonObject userInfoJson) {
+		return DefaultUserInfo.fromJson(userInfoJson);
+	}
 }


### PR DESCRIPTION
it must not be provided in Spring config

OIDCAuthenticationProvider: Setter for UserInfoFetcher, so own
implementation can be wired

UserInfoFetcher: Call to DefaultUserInfo.fromJson moved to method, so it
can be overwritten by own implementation to use own UserInfo
implementation