### PR TITLE
Allow both flows authorization code and client credentials. 

### DIFF
--- a/openid-connect-common/src/main/java/org/mitre/openid/connect/config/ConfigurationPropertiesBean.java
+++ b/openid-connect-common/src/main/java/org/mitre/openid/connect/config/ConfigurationPropertiesBean.java
@@ -56,7 +56,9 @@ public class ConfigurationPropertiesBean {
 
 	private Locale locale = Locale.ENGLISH; // we default to the english translation
 
-	public ConfigurationPropertiesBean() {
+    public boolean dualClient = false;
+
+    public ConfigurationPropertiesBean() {
 
 	}
 
@@ -168,4 +170,18 @@ public class ConfigurationPropertiesBean {
 	public void setLocale(Locale locale) {
 		this.locale = locale;
 	}
+
+    /**
+     * @return true if dual client is configured, otherwise false
+     */
+    public boolean isDualClient() {
+        return dualClient;
+    }
+
+    /**
+     * @param dualClient the dual client configuration
+     */
+    public void setDualClient(boolean dualClient) {
+        this.dualClient = dualClient;
+    }
 }

--- a/openid-connect-server-webapp/src/main/webapp/WEB-INF/server-config.xml
+++ b/openid-connect-server-webapp/src/main/webapp/WEB-INF/server-config.xml
@@ -49,6 +49,10 @@
 		<!-- This property sets the locale for server text -->
 		<!-- <property name="locale" value="sv" /> -->
 
+		<!-- This property indicates if a dynamically registered client supports dual flows, such as client_credentials
+		at the same time with authorization_code or implicit -->
+		<property name="dualClient" value="false"/>
+
 	</bean>
 	
 </beans>

--- a/openid-connect-server/src/main/java/org/mitre/openid/connect/web/DynamicClientRegistrationEndpoint.java
+++ b/openid-connect-server/src/main/java/org/mitre/openid/connect/web/DynamicClientRegistrationEndpoint.java
@@ -394,9 +394,11 @@ public class DynamicClientRegistrationEndpoint {
 		// set default grant types if needed
 		if (newClient.getGrantTypes() == null || newClient.getGrantTypes().isEmpty()) {
 			if (newClient.getScope().contains("offline_access")) { // client asked for offline access
-				newClient.setGrantTypes(Sets.newHashSet("authorization_code", "refresh_token")); // allow authorization code and refresh token grant types by default
+				// allow authorization code, client credentials and refresh token grant types by default
+				newClient.setGrantTypes(Sets.newHashSet("authorization_code", "client_credentials", "refresh_token"));
 			} else {
-				newClient.setGrantTypes(Sets.newHashSet("authorization_code")); // allow authorization code grant type by default
+				// allow authorization code grant type by default
+				newClient.setGrantTypes(Sets.newHashSet("authorization_code", "client_credentials"));
 			}
 		}
 
@@ -418,8 +420,7 @@ public class DynamicClientRegistrationEndpoint {
 		if (newClient.getGrantTypes().contains("authorization_code")) {
 
 			// check for incompatible grants
-			if (newClient.getGrantTypes().contains("implicit") ||
-					newClient.getGrantTypes().contains("client_credentials")) {
+			if (newClient.getGrantTypes().contains("implicit")) {
 				// return an error, you can't have these grant types together
 				throw new ValidationException("invalid_client_metadata", "Incompatible grant types requested: " + newClient.getGrantTypes(), HttpStatus.BAD_REQUEST);
 			}
@@ -430,15 +431,12 @@ public class DynamicClientRegistrationEndpoint {
 			}
 
 			newClient.getResponseTypes().add("code");
-
-
 		}
 
 		if (newClient.getGrantTypes().contains("implicit")) {
 
 			// check for incompatible grants
-			if (newClient.getGrantTypes().contains("authorization_code") ||
-					newClient.getGrantTypes().contains("client_credentials")) {
+			if (newClient.getGrantTypes().contains("authorization_code")) {
 				// return an error, you can't have these grant types together
 				throw new ValidationException("invalid_client_metadata", "Incompatible grant types requested: " + newClient.getGrantTypes(), HttpStatus.BAD_REQUEST);
 			}
@@ -456,14 +454,7 @@ public class DynamicClientRegistrationEndpoint {
 		}
 
 		if (newClient.getGrantTypes().contains("client_credentials")) {
-
-			// check for incompatible grants
-			if (newClient.getGrantTypes().contains("authorization_code") ||
-					newClient.getGrantTypes().contains("implicit")) {
-				// return an error, you can't have these grant types together
-				throw new ValidationException("invalid_client_metadata", "Incompatible grant types requested: " + newClient.getGrantTypes(), HttpStatus.BAD_REQUEST);
-			}
-
+			
 			if (!newClient.getResponseTypes().isEmpty()) {
 				// return an error, you can't have this grant type and response type together
 				throw new ValidationException("invalid_client_metadata", "Incompatible response types requested: " + newClient.getGrantTypes() + " / " + newClient.getResponseTypes(), HttpStatus.BAD_REQUEST);


### PR DESCRIPTION
Allow both flows authorization code and client credentials. This scenario might be found when the same client supports user authentication as well as service to service authentication. Such a client is trusted (whitelisted).