### PR TITLE
Update HikariCP to 2.4.1

### DIFF
--- a/openid-connect-server-webapp/pom.xml
+++ b/openid-connect-server-webapp/pom.xml
@@ -125,7 +125,7 @@
 
 		<dependency>
 			<groupId>com.zaxxer</groupId>
-			<artifactId>HikariCP-java6</artifactId>
+			<artifactId>HikariCP</artifactId>
 		</dependency>
 	</dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -534,8 +534,8 @@
 
 			<dependency>
 				<groupId>com.zaxxer</groupId>
-				<artifactId>HikariCP-java6</artifactId>
-				<version>2.3.8</version>
+				<artifactId>HikariCP</artifactId>
+				<version>2.4.1</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>


### PR DESCRIPTION
2.4.x has Java 7 support in the main artifact (no need for `-java6`).
https://github.com/brettwooldridge/HikariCP/blob/dev/CHANGES