### PR TITLE
Travis build on JDK 7+8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,6 @@
 language: java
+jdk:
+  - oraclejdk8
+  - oraclejdk7
+  - openjdk7
+sudo: false


### PR DESCRIPTION
Configures Travis to build on Oracle JDK 7+8 and OpenJDK 7.

Also enables migration to Travis' container-based infrastructure: http://docs.travis-ci.com/user/migrating-from-legacy/