### PR TITLE
Improve servlet startup speed

### DIFF
--- a/openid-connect-server-webapp/pom.xml
+++ b/openid-connect-server-webapp/pom.xml
@@ -78,6 +78,7 @@
 				<groupId>org.eclipse.jetty</groupId>
 				<artifactId>jetty-maven-plugin</artifactId>
 				<configuration>
+					<war>${project.build.directory}/openid-connect-server-webapp.war</war>
 					<webAppConfig>
 						<contextPath>/openid-connect-server-webapp</contextPath>
 					</webAppConfig>

--- a/openid-connect-server-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/openid-connect-server-webapp/src/main/webapp/WEB-INF/web.xml
@@ -17,7 +17,10 @@
 -->
 <web-app version="3.0" xmlns="http://java.sun.com/xml/ns/javaee"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
+	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+	metadata-complete="true">
+
+	<absolute-ordering />
 
 	<!-- The definition of the Root Spring Container shared by all Servlets 
 		and Filters -->

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
 				<plugin>
 					<groupId>org.eclipse.jetty</groupId>
 					<artifactId>jetty-maven-plugin</artifactId>
-					<version>9.1.1.v20140108</version>
+					<version>9.3.3.v20150827</version>
 				</plugin>
 				<plugin>
 					<inherited>true</inherited>


### PR DESCRIPTION
Update Jetty and configure `web.xml` for faster servlet start: 137580ms -> 20166ms for me.

Resolves #928.