### PR TITLE
Improve error message

### DIFF
--- a/openid-connect-server-webapp/src/main/webapp/WEB-INF/views/error.jsp
+++ b/openid-connect-server-webapp/src/main/webapp/WEB-INF/views/error.jsp
@@ -16,8 +16,8 @@ if (request.getAttribute("error") != null && request.getAttribute("error") insta
 } else if (request.getAttribute("javax.servlet.error.status_code") != null) {
 	Integer code = (Integer)request.getAttribute("javax.servlet.error.status_code");
 	HttpStatus status = HttpStatus.valueOf(code);
-	request.setAttribute("errorCode", status.toString());
-	request.setAttribute("message", status.getReasonPhrase());
+	request.setAttribute("errorCode", status.toString() + " " + status.getReasonPhrase());
+	request.setAttribute("message", request.getAttribute("javax.servlet.error.message"));
 } else {
 	request.setAttribute("errorCode", "Server error");
 	request.setAttribute("message", "See the logs for details");


### PR DESCRIPTION
Improve error message for errors with a status code:

Before:
![before](https://cloud.githubusercontent.com/assets/20283/10381178/ef39032a-6e18-11e5-9448-752eb7aee7ec.png)

After:
![after](https://cloud.githubusercontent.com/assets/20283/10381165/daa4b882-6e18-11e5-82ba-58a9044c31be.png)

These messages are usually swallowed by the logger (only visible on DEBUG level), so that's an extra argument for including them on the error page.