### PR TITLE
Remove legacy CSRF protection for approve page

### DIFF
--- a/openid-connect-server-webapp/src/main/webapp/WEB-INF/views/approve.jsp
+++ b/openid-connect-server-webapp/src/main/webapp/WEB-INF/views/approve.jsp
@@ -260,8 +260,8 @@
 				</h3>
                 <spring:message code="approve.label.authorize" var="authorize_label"/>
                 <spring:message code="approve.label.deny" var="deny_label"/>
-				<input id="user_oauth_approval" name="user_oauth_approval" value="true" type="hidden" /> 
-				<input name="csrf" value="${ csrf }" type="hidden" />
+				<input id="user_oauth_approval" name="user_oauth_approval" value="true" type="hidden" />
+				<input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}" />
 				<input name="authorize" value="${authorize_label}" type="submit"
 				onclick="$('#user_oauth_approval').attr('value',true)" class="btn btn-success btn-large" /> 
 				&nbsp; 

--- a/openid-connect-server/src/main/java/org/mitre/oauth2/web/OAuthConfirmationController.java
+++ b/openid-connect-server/src/main/java/org/mitre/oauth2/web/OAuthConfirmationController.java
@@ -57,7 +57,6 @@ import com.google.common.base.Strings;
 import com.google.common.collect.Sets;
 import com.google.gson.JsonObject;
 
-import static org.mitre.openid.connect.request.ConnectRequestParameters.CSRF;
 import static org.mitre.openid.connect.request.ConnectRequestParameters.PROMPT;
 import static org.mitre.openid.connect.request.ConnectRequestParameters.PROMPT_SEPARATOR;
 
@@ -220,9 +219,6 @@ public class OAuthConfirmationController {
 		} else {
 			model.put("gras", false);
 		}
-
-		// inject a random value for CSRF purposes
-		model.put("csrf", authRequest.getExtensions().get(CSRF));
 
 		return "approve";
 	}

--- a/openid-connect-server/src/main/java/org/mitre/openid/connect/request/ConnectOAuth2RequestFactory.java
+++ b/openid-connect-server/src/main/java/org/mitre/openid/connect/request/ConnectOAuth2RequestFactory.java
@@ -55,7 +55,6 @@ import com.nimbusds.jwt.SignedJWT;
 
 import static org.mitre.openid.connect.request.ConnectRequestParameters.CLAIMS;
 import static org.mitre.openid.connect.request.ConnectRequestParameters.CLIENT_ID;
-import static org.mitre.openid.connect.request.ConnectRequestParameters.CSRF;
 import static org.mitre.openid.connect.request.ConnectRequestParameters.DISPLAY;
 import static org.mitre.openid.connect.request.ConnectRequestParameters.LOGIN_HINT;
 import static org.mitre.openid.connect.request.ConnectRequestParameters.MAX_AGE;
@@ -156,13 +155,6 @@ public class ConnectOAuth2RequestFactory extends DefaultOAuth2RequestFactory {
 				logger.error("Caught OAuth2 exception trying to test client scopes and max age:", e);
 			}
 		}
-
-
-		// add CSRF protection to the request on first parse
-		String csrf = UUID.randomUUID().toString();
-		request.getExtensions().put(CSRF, csrf);
-
-
 
 		return request;
 	}

--- a/openid-connect-server/src/main/java/org/mitre/openid/connect/request/ConnectRequestParameters.java
+++ b/openid-connect-server/src/main/java/org/mitre/openid/connect/request/ConnectRequestParameters.java
@@ -38,7 +38,6 @@ public interface ConnectRequestParameters {
 	public String PROMPT_SEPARATOR = " ";
 
 	// extensions
-	public String CSRF = "csrf";
 	public String APPROVED_SITE = "approved_site";
 
 	// responses

--- a/openid-connect-server/src/main/java/org/mitre/openid/connect/token/TofuUserApprovalHandler.java
+++ b/openid-connect-server/src/main/java/org/mitre/openid/connect/token/TofuUserApprovalHandler.java
@@ -48,7 +48,6 @@ import com.google.common.base.Strings;
 import com.google.common.collect.Sets;
 
 import static org.mitre.openid.connect.request.ConnectRequestParameters.APPROVED_SITE;
-import static org.mitre.openid.connect.request.ConnectRequestParameters.CSRF;
 import static org.mitre.openid.connect.request.ConnectRequestParameters.PROMPT;
 import static org.mitre.openid.connect.request.ConnectRequestParameters.PROMPT_SEPARATOR;
 
@@ -102,21 +101,8 @@ public class TofuUserApprovalHandler implements UserApprovalHandler {
 			return true;
 		} else {
 			// if not, check to see if the user has approved it
-			if (Boolean.parseBoolean(authorizationRequest.getApprovalParameters().get("user_oauth_approval"))) {			// TODO: make parameter name configurable?
-
-				// check the value of the CSRF parameter
-
-				if (authorizationRequest.getExtensions().get(CSRF) != null) {
-					if (authorizationRequest.getExtensions().get(CSRF).equals(authorizationRequest.getApprovalParameters().get(CSRF))) {
-
-						// make sure the user is actually authenticated
-						return userAuthentication.isAuthenticated();
-					}
-				}
-			}
-
-			// if the above doesn't pass, it's not yet approved
-			return false;
+			// TODO: make parameter name configurable?
+			return Boolean.parseBoolean(authorizationRequest.getApprovalParameters().get("user_oauth_approval"));
 		}
 
 	}
@@ -195,9 +181,7 @@ public class TofuUserApprovalHandler implements UserApprovalHandler {
 		ClientDetails client = clientDetailsService.loadClientByClientId(clientId);
 
 		// This must be re-parsed here because SECOAUTH forces us to call things in a strange order
-		if (Boolean.parseBoolean(authorizationRequest.getApprovalParameters().get("user_oauth_approval"))
-				&& authorizationRequest.getExtensions().get(CSRF) != null
-				&& authorizationRequest.getExtensions().get(CSRF).equals(authorizationRequest.getApprovalParameters().get(CSRF))) {
+		if (Boolean.parseBoolean(authorizationRequest.getApprovalParameters().get("user_oauth_approval"))) {
 
 			authorizationRequest.setApproved(true);
 


### PR DESCRIPTION
Instead, we rely on the Spring Security CSRF protection, like we already do for the login page. Additionally, we remove the authentication check in`isApproved`, because this is already done by Spring Security (and if not, we have bigger problems to worry about).

Resolves #931.

Because this issue impacts core behaviour, I'd think this would be sufficient reason for a release of 1.2.2.