### PR TITLE
Upgrade to Spring Framework 4.1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -259,7 +259,7 @@
 			<dependency>
 				<groupId>org.springframework</groupId>
 				<artifactId>spring-framework-bom</artifactId>
-				<version>4.1.7.RELEASE</version>
+				<version>4.1.8.RELEASE</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>


### PR DESCRIPTION
http://spring.io/blog/2015/10/15/spring-framework-4-2-2-4-1-8-and-3-2-15-available-now

The Spring Framework 4.2 series have also been stable for a while now, but maybe that's more suited for a 1.3 release.