### PR TITLE
Make FILTER_PROCESSES_URL public

### DIFF
--- a/openid-connect-client/src/main/java/org/mitre/openid/connect/client/OIDCAuthenticationFilter.java
+++ b/openid-connect-client/src/main/java/org/mitre/openid/connect/client/OIDCAuthenticationFilter.java
@@ -96,7 +96,7 @@ public class OIDCAuthenticationFilter extends AbstractAuthenticationProcessingFi
 	protected static final String TARGET_SESSION_VARIABLE = "target";
 	protected final static int HTTP_SOCKET_TIMEOUT = 30000;
 
-	protected final static String FILTER_PROCESSES_URL = "/openid_connect_login";
+	public final static String FILTER_PROCESSES_URL = "/openid_connect_login";
 
 	// Allow for time sync issues by having a window of X seconds.
 	private int timeSkewAllowance = 300;


### PR DESCRIPTION
Currently hardcoded in the filter and the client's Spring Security config; would be nicer to reference the value instead.

https://github.com/mitreid-connect/simple-web-app/blob/c5e70ebd5c28de2cce81d106435ae11925424a5f/src/main/webapp/WEB-INF/spring/appServlet/servlet-context.xml#L54