### PR TITLE
Align user profile claims

### DIFF
--- a/openid-connect-server-webapp/src/main/webapp/resources/css/mitreid-connect.css
+++ b/openid-connect-server-webapp/src/main/webapp/resources/css/mitreid-connect.css
@@ -181,3 +181,8 @@ h1,label {
   vertical-align: middle;
   margin: 0;
 }
+
+/* User profile claims alignment */
+.user-profile dd, .user-profile dt {
+    height: 20px;
+}

--- a/openid-connect-server-webapp/src/main/webapp/resources/template/admin.html
+++ b/openid-connect-server-webapp/src/main/webapp/resources/template/admin.html
@@ -96,7 +96,7 @@
 
 	<div data-i18n="admin.user-profile.text">Your user profile has the following information:</div>
 
-    <dl class="dl-horizontal">
+    <dl class="dl-horizontal user-profile">
 		<dt><span class="text-info" data-i18n="admin.user-profile.claim">Claim name:</span></dt>
 		<dd><span class="text-info" data-i18n="admin.user-profile.value">Claim value:</span></dt>
     </dl>


### PR DESCRIPTION
Especially helps when `<dd>` collapses due to an empty claim value.

Related to https://github.com/mitreid-connect/OpenID-Connect-Java-Spring-Server/issues/553#issuecomment-118527610