### PR TITLE
Bugfix for multiple client redirects in UUIDPairwiseIdentiferService

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ bin
 /target
 .springBeans
 nb-configuration.xml
+.java-version

--- a/openid-connect-server/src/main/java/org/mitre/openid/connect/service/impl/UUIDPairwiseIdentiferService.java
+++ b/openid-connect-server/src/main/java/org/mitre/openid/connect/service/impl/UUIDPairwiseIdentiferService.java
@@ -31,6 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
 import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -56,13 +57,13 @@ public class UUIDPairwiseIdentiferService implements PairwiseIdentiferService {
 	public String getIdentifier(UserInfo userInfo, ClientDetailsEntity client) {
 
 		String sectorIdentifier = null;
+		Set<String> redirectUris = client.getRedirectUris();
 
 		if (!Strings.isNullOrEmpty(client.getSectorIdentifierUri())) {
 			UriComponents uri = UriComponentsBuilder.fromUriString(client.getSectorIdentifierUri()).build();
 			sectorIdentifier = uri.getHost(); // calculate based on the host component only
-		} else {
-			Set<String> redirectUris = client.getRedirectUris();
-			UriComponents uri = UriComponentsBuilder.fromUriString(Iterables.getOnlyElement(redirectUris)).build();
+		} else if (!CollectionUtils.isEmpty(redirectUris)) {
+			UriComponents uri = UriComponentsBuilder.fromUriString(redirectUris.iterator().next()).build();
 			sectorIdentifier = uri.getHost(); // calculate based on the host of the only redirect URI
 		}
 
@@ -83,7 +84,7 @@ public class UUIDPairwiseIdentiferService implements PairwiseIdentiferService {
 
 			return pairwise.getIdentifier();
 		} else {
-
+			logger.warn("Could not calculate a pairwise subject identifier for userInfo {} and client {}", userInfo.getPreferredUsername(), client.getClientId());
 			return null;
 		}
 	}

--- a/openid-connect-server/src/test/java/org/mitre/openid/connect/service/impl/TestUUIDPairwiseIdentiferService.java
+++ b/openid-connect-server/src/test/java/org/mitre/openid/connect/service/impl/TestUUIDPairwiseIdentiferService.java
@@ -41,6 +41,7 @@ import com.google.common.collect.ImmutableSet;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
 
 /**
  * @author jricher
@@ -192,9 +193,10 @@ public class TestUUIDPairwiseIdentiferService {
 
 	}
 
-	@Test(expected = IllegalArgumentException.class)
-	public void testGetIdentifier_multipleRedirectError() {
+	@Test
+	public void testGetIdentifier_multipleRedirects() {
 		String pairwise5 = service.getIdentifier(userInfoRegular, pairwiseClient5);
+		UUID.fromString(pairwise5);
 	}
 
 }


### PR DESCRIPTION
When a client has multiple redirect URIs, no configured
sectorIdentifierUri and the subject type is PAIRWISE then
the UUIDPairwiseIdentiferService#getIdentifier should not
fail, but instead use the first redirect URI for calculating
the sector identifier. Fixes#969