### PR TITLE
Add basic implementation of end session endpoint

### DIFF
--- a/openid-connect-server-webapp/src/main/webapp/WEB-INF/views/logout.jsp
+++ b/openid-connect-server-webapp/src/main/webapp/WEB-INF/views/logout.jsp
@@ -1,0 +1,38 @@
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
+<%@ taglib prefix="o" tagdir="/WEB-INF/tags"%>
+<%@ taglib prefix="security" uri="http://www.springframework.org/security/tags"%>
+<%@ taglib prefix="spring" uri="http://www.springframework.org/tags"%>
+
+<spring:message code="logout.title" var="title"/>
+<o:header title="${title}"/>
+<o:topbar pageName="Logout"/>
+<div class="container-fluid main">
+	<div class="row-fluid">
+		<div class="span1"></div>
+		<div class="span10">
+            <security:authorize access="hasRole('ROLE_USER')">
+				<div class="hero-unit">
+					<h2><spring:message code="logout.title"/></h2>
+					<p>
+						<spring:message code="logout.body"/>
+					</p>
+					<p>
+						<a href="" class="btn btn-primary btn-large endSessionLogoutLink"><spring:message code="topbar.logout"/></a>
+		                <form action="${ config.issuer }${ config.issuer.endsWith('/') ? '' : '/' }logout" method="POST" class="hidden" id="endSessionLogoutForm">
+							<input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}" />
+						</form>
+					</p>
+				</div>
+            </security:authorize>
+		</div>
+	</div>
+</div>
+<o:footer/>
+<script type="text/javascript">
+	$(document).ready(function() {
+		$('.endSessionLogoutLink').on('click', function(e) {
+			e.preventDefault();
+			$('#endSessionLogoutForm').submit();
+		});
+	});
+</script>

--- a/openid-connect-server-webapp/src/main/webapp/resources/js/locale/en/messages.json
+++ b/openid-connect-server-webapp/src/main/webapp/resources/js/locale/en/messages.json
@@ -349,6 +349,10 @@
 		"title": "About",
 		"body": "\nThis OpenID Connect service is built from the MITREid Connect Open Source project, from \n<a href=\"http://www.mitre.org/\">The MITRE Corporation</a> and the <a href=\"http://kit.mit.edu/\">MIT Kerberos and Internet Trust Consortium</a>.\n</p>\n<p>\nMore information about the project can be found at \n<a href=\"http://github.com/mitreid-connect/\">MITREid Connect on GitHub</a>. \nThere, you can submit bug reports, give feedback, or even contribute code patches for additional features you'd like to see."
 	},
+	"logout": {
+		"title": "Log out",
+		"body": "Are you sure you want to log out?"
+	},
 	"statistics": {
 		"title": "Statistics",
 		"number_users": "Number of users: <span class=\"label label-info\" id=\"userCount\">{0}</span>",

--- a/openid-connect-server/src/main/java/org/mitre/discovery/web/DiscoveryEndpoint.java
+++ b/openid-connect-server/src/main/java/org/mitre/discovery/web/DiscoveryEndpoint.java
@@ -33,6 +33,7 @@ import org.mitre.openid.connect.service.UserInfoService;
 import org.mitre.openid.connect.view.HttpCodeView;
 import org.mitre.openid.connect.view.JsonEntityView;
 import org.mitre.openid.connect.web.DynamicClientRegistrationEndpoint;
+import org.mitre.openid.connect.web.EndSessionEndpoint;
 import org.mitre.openid.connect.web.JWKSetPublishingEndpoint;
 import org.mitre.openid.connect.web.UserInfoEndpoint;
 import org.slf4j.Logger;
@@ -305,7 +306,7 @@ public class DiscoveryEndpoint {
 		m.put("token_endpoint", baseUrl + "token");
 		m.put("userinfo_endpoint", baseUrl + UserInfoEndpoint.URL);
 		//check_session_iframe
-		//end_session_endpoint
+		m.put("end_session_endpoint", baseUrl + EndSessionEndpoint.URL);
 		m.put("jwks_uri", baseUrl + JWKSetPublishingEndpoint.URL);
 		m.put("registration_endpoint", baseUrl + DynamicClientRegistrationEndpoint.URL);
 		m.put("scopes_supported", scopeService.toStrings(scopeService.getUnrestricted())); // these are the scopes that you can dynamically register for, which is what matters for discovery

--- a/openid-connect-server/src/main/java/org/mitre/openid/connect/web/EndSessionEndpoint.java
+++ b/openid-connect-server/src/main/java/org/mitre/openid/connect/web/EndSessionEndpoint.java
@@ -1,0 +1,97 @@
+/*******************************************************************************
+ * Copyright 2015 The MITRE Corporation
+ *   and the MIT Kerberos and Internet Trust Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.mitre.openid.connect.web;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.mitre.oauth2.model.OAuth2AccessTokenEntity;
+import org.mitre.oauth2.service.OAuth2TokenEntityService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+/**
+ * OpenID Connect EndSession endpoint, as specified in https://openid.net/specs/openid-connect-session-1_0.html
+ * 
+ * @author SDOXSEE
+ *
+ */
+@Controller
+@PreAuthorize("hasRole('ROLE_USER')")
+public class EndSessionEndpoint {
+
+	public static final String URL = "endsession";
+	
+	@Autowired
+	EndSessionValidator endSessionValidator;
+
+	@Autowired
+	OAuth2TokenEntityService tokenService;
+	
+	@Autowired
+	SignOutHelper signOutHelper;
+	
+	/**
+	 * Logger for this class
+	 */
+	private static final Logger logger = LoggerFactory.getLogger(EndSessionEndpoint.class);
+
+	/**
+	 * Get information about the user as specified in the accessToken included in this request
+	 */
+	@RequestMapping(value="/" + EndSessionEndpoint.URL, method= {RequestMethod.GET})
+	public String getEndSession(
+			@RequestParam(value="id_token_hint", required=false) String idTokenHint,
+			@RequestParam(value="post_logout_redirect_uri", required=false, defaultValue="") String postLogoutRedirectUri,
+			AbstractAuthenticationToken auth, Model model, final RedirectAttributes redirectAttributes, HttpServletRequest request) {
+
+		if (endSessionValidator.isValid(idTokenHint, postLogoutRedirectUri, auth)) {
+			try {
+				OAuth2AccessTokenEntity accessToken = tokenService.readAccessToken(idTokenHint);
+				tokenService.revokeAccessToken(accessToken);
+			} catch (Exception e) {
+				logger.warn("Couldn't revoke valid id_token: " + idTokenHint);
+				// if we can't revoke the token, not the end of the world. Carry on
+			}
+			signOutHelper.signOutProgrammatically(request);
+			return "redirect:" + postLogoutRedirectUri;
+		} else {
+			redirectAttributes.addFlashAttribute("id_token_hint", idTokenHint);
+			redirectAttributes.addFlashAttribute("post_logout_redirect_uri", postLogoutRedirectUri);
+			
+			return "redirect:/logout";
+		}
+	}
+
+	@RequestMapping(value="/logout", method= {RequestMethod.GET})
+	protected ModelAndView handleRequestInternal(HttpServletRequest request,
+		HttpServletResponse response) throws Exception {
+		
+		return new ModelAndView("logout");
+	}
+	
+}

--- a/openid-connect-server/src/main/java/org/mitre/openid/connect/web/EndSessionEndpoint.java
+++ b/openid-connect-server/src/main/java/org/mitre/openid/connect/web/EndSessionEndpoint.java
@@ -47,13 +47,13 @@ public class EndSessionEndpoint {
 	public static final String URL = "endsession";
 	
 	@Autowired
-	EndSessionValidator endSessionValidator;
+	private EndSessionValidator endSessionValidator;
 
 	@Autowired
-	OAuth2TokenEntityService tokenService;
+	private OAuth2TokenEntityService tokenService;
 	
 	@Autowired
-	SignOutHelper signOutHelper;
+	private SignOutHelper signOutHelper;
 	
 	/**
 	 * Logger for this class
@@ -92,6 +92,18 @@ public class EndSessionEndpoint {
 		HttpServletResponse response) throws Exception {
 		
 		return new ModelAndView("logout");
+	}
+
+	public void setTokenService(OAuth2TokenEntityService tokenService) {
+		this.tokenService = tokenService;
+	}
+
+	public void setEndSessionValidator(EndSessionValidator endSessionValidator) {
+		this.endSessionValidator = endSessionValidator;
+	}
+
+	public void setSignOutHelper(SignOutHelper signOutHelper) {
+		this.signOutHelper = signOutHelper;
 	}
 	
 }

--- a/openid-connect-server/src/main/java/org/mitre/openid/connect/web/EndSessionValidator.java
+++ b/openid-connect-server/src/main/java/org/mitre/openid/connect/web/EndSessionValidator.java
@@ -22,7 +22,7 @@ public class EndSessionValidator {
 	private static final Logger logger = LoggerFactory.getLogger(EndSessionValidator.class);
 	
 	@Autowired
-	OAuth2TokenEntityService tokenService;
+	private OAuth2TokenEntityService tokenService;
 
 	public boolean isValid(String idTokenHint, String postLogoutRedirectUri, AbstractAuthenticationToken auth) {
 		if (idTokenHint == null || !isValidSyntax(idTokenHint) || isEmpty(postLogoutRedirectUri)) {
@@ -54,9 +54,9 @@ public class EndSessionValidator {
 		try {
 			accessToken = tokenService.readAccessToken(idTokenHint);
 		} catch (AuthenticationException e) {
-			logger.info("Error reading id_token: " + idTokenHint, e);
+			logger.info("Error reading id_token: " + idTokenHint);
 		} catch (InvalidTokenException e) {
-			logger.info("Error reading id_token: " + idTokenHint, e);
+			logger.info("Error reading id_token: " + idTokenHint);
 		}
 		return accessToken;
 	}
@@ -66,10 +66,13 @@ public class EndSessionValidator {
 			SignedJWT.parse(idTokenHint);
 			return true;
 		} catch (ParseException e) {
-			e.printStackTrace();
 			logger.info("bad id_token: " + idTokenHint);
 			return false;
 		}
+	}
+
+	public void setTokenService(OAuth2TokenEntityService tokenService) {
+		this.tokenService = tokenService;
 	}
 
 }

--- a/openid-connect-server/src/main/java/org/mitre/openid/connect/web/EndSessionValidator.java
+++ b/openid-connect-server/src/main/java/org/mitre/openid/connect/web/EndSessionValidator.java
@@ -1,0 +1,75 @@
+package org.mitre.openid.connect.web;
+
+import static org.springframework.util.StringUtils.isEmpty;
+
+import java.text.ParseException;
+
+import org.mitre.oauth2.model.OAuth2AccessTokenEntity;
+import org.mitre.oauth2.service.OAuth2TokenEntityService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.common.exceptions.InvalidTokenException;
+import org.springframework.stereotype.Component;
+
+import com.nimbusds.jwt.SignedJWT;
+
+@Component
+public class EndSessionValidator {
+	
+	private static final Logger logger = LoggerFactory.getLogger(EndSessionValidator.class);
+	
+	@Autowired
+	OAuth2TokenEntityService tokenService;
+
+	public boolean isValid(String idTokenHint, String postLogoutRedirectUri, AbstractAuthenticationToken auth) {
+		if (idTokenHint == null || !isValidSyntax(idTokenHint) || isEmpty(postLogoutRedirectUri)) {
+			return false;
+		}
+		OAuth2AccessTokenEntity accessToken = findAccessToken(idTokenHint);
+		if (accessToken == null || 
+				accessToken.getClient() == null) {
+			return false;
+		} else if (accessToken.getClient().getPostLogoutRedirectUris() == null ||
+				!accessToken.getClient().getPostLogoutRedirectUris().contains(postLogoutRedirectUri)) {
+			logger.info("Unregistered post_logout_redirect_uri: " + postLogoutRedirectUri);
+			return false;
+		} else if (accessToken.getAuthenticationHolder() == null ||
+				accessToken.getAuthenticationHolder().getUserAuth() == null ||
+				accessToken.getAuthenticationHolder().getUserAuth().getName() == null ||
+				auth == null ||
+				auth.getPrincipal() == null ||
+				!accessToken.getAuthenticationHolder().getUserAuth().getName().equals(auth.getPrincipal())) {
+			logger.info("Can't verify correct user for logout");
+			return false;
+		} else {
+			return true;
+		}
+	}
+
+	private OAuth2AccessTokenEntity findAccessToken(String idTokenHint) {
+		OAuth2AccessTokenEntity accessToken = null;
+		try {
+			accessToken = tokenService.readAccessToken(idTokenHint);
+		} catch (AuthenticationException e) {
+			logger.info("Error reading id_token: " + idTokenHint, e);
+		} catch (InvalidTokenException e) {
+			logger.info("Error reading id_token: " + idTokenHint, e);
+		}
+		return accessToken;
+	}
+
+	private boolean isValidSyntax(String idTokenHint) {
+		try {
+			SignedJWT.parse(idTokenHint);
+			return true;
+		} catch (ParseException e) {
+			e.printStackTrace();
+			logger.info("bad id_token: " + idTokenHint);
+			return false;
+		}
+	}
+
+}

--- a/openid-connect-server/src/main/java/org/mitre/openid/connect/web/SignOutHelper.java
+++ b/openid-connect-server/src/main/java/org/mitre/openid/connect/web/SignOutHelper.java
@@ -1,0 +1,15 @@
+package org.mitre.openid.connect.web;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SignOutHelper {
+
+	// http://stackoverflow.com/a/18957784/1098564
+	public void signOutProgrammatically(HttpServletRequest request) {
+		new SecurityContextLogoutHandler().logout(request, null, null);
+	}
+}

--- a/openid-connect-server/src/test/java/org/mitre/openid/connect/web/EndSessionEndpointTest.java
+++ b/openid-connect-server/src/test/java/org/mitre/openid/connect/web/EndSessionEndpointTest.java
@@ -33,9 +33,9 @@ public class EndSessionEndpointTest {
 	@Before
 	public void before() {
 		fixture = new EndSessionEndpoint();
-		fixture.tokenService = tokenService;
-		fixture.endSessionValidator = endSessionValidator;
-		fixture.signOutHelper = signOutHelper;
+		fixture.setTokenService(tokenService);
+		fixture.setEndSessionValidator(endSessionValidator);
+		fixture.setSignOutHelper(signOutHelper);
 	}
 
 	@Test

--- a/openid-connect-server/src/test/java/org/mitre/openid/connect/web/EndSessionEndpointTest.java
+++ b/openid-connect-server/src/test/java/org/mitre/openid/connect/web/EndSessionEndpointTest.java
@@ -1,0 +1,85 @@
+package org.mitre.openid.connect.web;
+
+import static org.junit.Assert.assertEquals;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mitre.oauth2.model.OAuth2AccessTokenEntity;
+import org.mitre.oauth2.service.OAuth2TokenEntityService;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.ui.Model;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+@RunWith(MockitoJUnitRunner.class)
+public class EndSessionEndpointTest {
+	
+	private static final String REDIRECT = "http://foo.com";
+	private static final String JWT = "eyJraWQiOiJyc2ExIiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiI0N0ZBNTMyRi1BNUI2LUUzMTEtOEUxQy0wMDFGMjlEREZGMjgiLCJhdWQiOiJwZV90ZXN0Iiwia2lkIjoicnNhMSIsImlzcyI6Imh0dHBzOlwvXC9vcHJjLmJiZC5jYVwvIiwiZXhwIjoxNDQ3MjY5ODgzLCJpYXQiOjE0NDcyNjkyODMsImp0aSI6IjUyNmJiZWI2LTFhZGQtNGFhNi05NGUyLWE4NzM2YjQwYjBlMiJ9.NQpjQ2w7WwCtpWq6SkOaD6NUghWpjFv7e0LmZ6NSlTR3WzJTFUBDWqb5Q9Mf7nxTvacJrJZDS_Z66qIeky_0x9y0gE5GzNwWUgdomQ4QFiuYjrJQkMp8Nz-1xcMBAc8AgJfx5TDWJPTT8LZpWjHSYHiotVXIx9EHSLIBnt3hMQ0j4rOHZSPnAeA7c4yJz4V1kGyCfpQVoCBWaVnIuvFE9UnpunHgMaVpb_w7sW4yYBJ4e6n-WPCUrjNyWuqEiEOhqtblQcp6HJwIkrxaRb6riu7C2UT05oJVkgNAKosLvjIz176MCVOgw2WPu7HP4qrmvpnQH_xAz6rjkPC3f7Fj1w";
+	@Mock Model model;
+	@Mock AbstractAuthenticationToken auth;
+	@Mock RedirectAttributes redirectAttributes;
+	@Mock HttpServletRequest request;
+	@Mock OAuth2TokenEntityService tokenService;
+	@Mock EndSessionValidator endSessionValidator;
+	@Mock SignOutHelper signOutHelper;
+	private EndSessionEndpoint fixture;
+	
+	@Before
+	public void before() {
+		fixture = new EndSessionEndpoint();
+		fixture.tokenService = tokenService;
+		fixture.endSessionValidator = endSessionValidator;
+		fixture.signOutHelper = signOutHelper;
+	}
+
+	@Test
+	public void shouldReturnLogoutViewIfInvalid() throws Exception {
+		
+		mockValid(false);
+		
+		String view = fixture.getEndSession(JWT, REDIRECT, auth, model, redirectAttributes, request);
+		
+		assertEquals("redirect:/logout", view);
+	}
+
+	private void mockValid(boolean isValid) {
+		Mockito.when(endSessionValidator.isValid(Mockito.anyString(), Mockito.anyString(), Mockito.any(AbstractAuthenticationToken.class))).thenReturn(isValid);
+	}
+
+	@Test
+	public void shouldReturnPostLogoutRedirectUriIfValid() throws Exception {
+		
+		mockValid(true);
+		
+		String view = fixture.getEndSession(JWT, REDIRECT, auth, model, redirectAttributes, request);
+		
+		assertEquals("redirect:" + REDIRECT, view);
+	}
+	
+	@Test
+	public void shouldDeleteTokenIfValid() throws Exception {
+		
+		mockValid(true);
+		
+		fixture.getEndSession(JWT, REDIRECT, auth, model, redirectAttributes, request);
+		
+		Mockito.verify(tokenService).revokeAccessToken(Mockito.any(OAuth2AccessTokenEntity.class));
+	}
+	
+	@Test
+	public void shouldSignOutProgrammaticallyIfValid() throws Exception {
+
+		mockValid(true);
+		
+		fixture.getEndSession(JWT, REDIRECT, auth, model, redirectAttributes, request);
+		
+		Mockito.verify(signOutHelper).signOutProgrammatically(Mockito.any(HttpServletRequest.class));
+	}
+	
+}

--- a/openid-connect-server/src/test/java/org/mitre/openid/connect/web/EndSessionTestHelper.java
+++ b/openid-connect-server/src/test/java/org/mitre/openid/connect/web/EndSessionTestHelper.java
@@ -1,0 +1,34 @@
+package org.mitre.openid.connect.web;
+
+import java.util.Arrays;
+import java.util.HashSet;
+
+import org.mitre.oauth2.model.AuthenticationHolderEntity;
+import org.mitre.oauth2.model.ClientDetailsEntity;
+import org.mitre.oauth2.model.OAuth2AccessTokenEntity;
+import org.mitre.oauth2.model.SavedUserAuthentication;
+
+public class EndSessionTestHelper {
+
+	public static OAuth2AccessTokenEntity createClientDetailsWithPostLogoutRedirectUri(String registeredRedirect, String username) {
+			OAuth2AccessTokenEntity value = new OAuth2AccessTokenEntity();
+			value.setClient(createClient(registeredRedirect));
+			value.setAuthenticationHolder(createAuthenticationHolder(username));
+			return value;
+	}
+
+	private static AuthenticationHolderEntity createAuthenticationHolder(String username) {
+		AuthenticationHolderEntity authenticationHolder = new AuthenticationHolderEntity();
+		SavedUserAuthentication userAuth = new SavedUserAuthentication();
+		userAuth.setName(username);
+		authenticationHolder.setUserAuth(userAuth);
+		return authenticationHolder;
+	}
+
+	private static ClientDetailsEntity createClient(String registeredRedirect) {
+		ClientDetailsEntity client = new ClientDetailsEntity();
+		client.setPostLogoutRedirectUris(new HashSet<String>(Arrays.asList(registeredRedirect)));
+		return client;
+	}
+
+}

--- a/openid-connect-server/src/test/java/org/mitre/openid/connect/web/EndSessionValidatorTest.java
+++ b/openid-connect-server/src/test/java/org/mitre/openid/connect/web/EndSessionValidatorTest.java
@@ -31,7 +31,7 @@ public class EndSessionValidatorTest {
 	@Before
 	public void before() {
 		fixture = new EndSessionValidator();
-		fixture.tokenService = tokenService;
+		fixture.setTokenService(tokenService);
 	}
 	
 	@Test

--- a/openid-connect-server/src/test/java/org/mitre/openid/connect/web/EndSessionValidatorTest.java
+++ b/openid-connect-server/src/test/java/org/mitre/openid/connect/web/EndSessionValidatorTest.java
@@ -1,0 +1,96 @@
+package org.mitre.openid.connect.web;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mitre.oauth2.service.OAuth2TokenEntityService;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.oauth2.common.exceptions.InvalidTokenException;
+
+@RunWith(MockitoJUnitRunner.class)
+public class EndSessionValidatorTest {
+	
+	private static final String USERNAME = "bar@foo.com";
+	private static final String REDIRECT = "http://redirect.com";
+	private static final String NULL_REDIRECT = null;
+	private static final String BAD_REDIRECT = "http://malory.com";
+	
+	private static final String NULL_JWT = null;
+	private static final String BAD_JWT = "ey.foo.bar";
+	private static final String GOOD_JWT = "eyJraWQiOiJyc2ExIiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiI0N0ZBNTMyRi1BNUI2LUUzMTEtOEUxQy0wMDFGMjlEREZGMjgiLCJhdWQiOiJwZV90ZXN0Iiwia2lkIjoicnNhMSIsImlzcyI6Imh0dHBzOlwvXC9vcHJjLmJiZC5jYVwvIiwiZXhwIjoxNDQ3MjY5ODgzLCJpYXQiOjE0NDcyNjkyODMsImp0aSI6IjUyNmJiZWI2LTFhZGQtNGFhNi05NGUyLWE4NzM2YjQwYjBlMiJ9.NQpjQ2w7WwCtpWq6SkOaD6NUghWpjFv7e0LmZ6NSlTR3WzJTFUBDWqb5Q9Mf7nxTvacJrJZDS_Z66qIeky_0x9y0gE5GzNwWUgdomQ4QFiuYjrJQkMp8Nz-1xcMBAc8AgJfx5TDWJPTT8LZpWjHSYHiotVXIx9EHSLIBnt3hMQ0j4rOHZSPnAeA7c4yJz4V1kGyCfpQVoCBWaVnIuvFE9UnpunHgMaVpb_w7sW4yYBJ4e6n-WPCUrjNyWuqEiEOhqtblQcp6HJwIkrxaRb6riu7C2UT05oJVkgNAKosLvjIz176MCVOgw2WPu7HP4qrmvpnQH_xAz6rjkPC3f7Fj1w";
+	
+	@Mock AbstractAuthenticationToken auth;
+	@Mock OAuth2TokenEntityService tokenService;
+	
+	private EndSessionValidator fixture;
+	
+	@Before
+	public void before() {
+		fixture = new EndSessionValidator();
+		fixture.tokenService = tokenService;
+	}
+	
+	@Test
+	public void shouldNotAcceptNullJwt() throws Exception {
+		boolean valid = fixture.isValid(NULL_JWT, REDIRECT, auth);
+		
+		Assert.assertTrue(!valid);
+	}
+	@Test
+	public void shouldNotAcceptBadJwt() throws Exception {
+		boolean valid = fixture.isValid(BAD_JWT, REDIRECT, auth);
+		
+		Assert.assertTrue(!valid);
+	}
+	@Test
+	public void shouldNotAcceptBlankRedirect() throws Exception {
+		boolean valid = fixture.isValid(GOOD_JWT, NULL_REDIRECT, auth);
+		
+		Assert.assertTrue(!valid);
+	}
+	@Test
+	public void shouldNotAcceptIfTokenLookupFails() throws Exception {
+		
+		Mockito.when(tokenService.readAccessToken(GOOD_JWT)).thenThrow(new InvalidTokenException(""));
+		
+		boolean valid = fixture.isValid(GOOD_JWT, REDIRECT, auth);
+		
+		Assert.assertTrue(!valid);
+		
+	}
+	@Test
+	public void shouldNotAcceptIfTokenForWrongUser() throws Exception {
+		Mockito.when(auth.getPrincipal()).thenReturn("foo@foo.com");
+		
+		Mockito.when(tokenService.readAccessToken(GOOD_JWT)).thenReturn(EndSessionTestHelper.createClientDetailsWithPostLogoutRedirectUri(REDIRECT, USERNAME));
+		
+		boolean valid = fixture.isValid(GOOD_JWT, REDIRECT, auth);
+		
+		Assert.assertTrue(!valid);
+		
+	}
+	@Test
+	public void shouldNotAcceptIfPostLogoutRedirectUriNotFound() throws Exception {
+		
+		Mockito.when(tokenService.readAccessToken(GOOD_JWT)).thenReturn(EndSessionTestHelper.createClientDetailsWithPostLogoutRedirectUri(REDIRECT, USERNAME));
+		
+		boolean valid = fixture.isValid(GOOD_JWT, BAD_REDIRECT, auth);
+		
+		Assert.assertTrue(!valid);
+	}
+	@Test
+	public void shouldAcceptGoodJwtAndRedirect() throws Exception {
+		
+		Mockito.when(auth.getPrincipal()).thenReturn(USERNAME);
+		Mockito.when(tokenService.readAccessToken(GOOD_JWT)).thenReturn(EndSessionTestHelper.createClientDetailsWithPostLogoutRedirectUri(REDIRECT, USERNAME));
+		
+		boolean valid = fixture.isValid(GOOD_JWT, REDIRECT, auth);
+		
+		Assert.assertTrue(valid);
+	}
+	
+}


### PR DESCRIPTION
This addresses the RP-initiated logout section of the session management spec (https://openid.net/specs/openid-connect-session-1_0.html) and has some gaps. I'm creating this PR in case other people want a starting point for implementing it themselves (rather than start with nothing).
