### PR TITLE
Update the BlacklistAwareRedirectResolver to work with non standard URL

### DIFF
--- a/openid-connect-server/src/main/java/org/mitre/oauth2/service/impl/BlacklistAwareRedirectResolver.java
+++ b/openid-connect-server/src/main/java/org/mitre/oauth2/service/impl/BlacklistAwareRedirectResolver.java
@@ -1,5 +1,5 @@
 /**
- * 
+ *
  */
 package org.mitre.oauth2.service.impl;
 
@@ -10,30 +10,62 @@ import org.springframework.security.oauth2.common.exceptions.OAuth2Exception;
 import org.springframework.security.oauth2.provider.ClientDetails;
 import org.springframework.security.oauth2.provider.endpoint.DefaultRedirectResolver;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
 
 /**
  * @author jricher
- *
  */
 @Component("blacklistAwareRedirectResolver")
 public class BlacklistAwareRedirectResolver extends DefaultRedirectResolver {
 
-	@Autowired
-	private BlacklistedSiteService blacklistService;
-	
-	/* (non-Javadoc)
-	 * @see org.springframework.security.oauth2.provider.endpoint.RedirectResolver#resolveRedirect(java.lang.String, org.springframework.security.oauth2.provider.ClientDetails)
-	 */
-	@Override
-	public String resolveRedirect(String requestedRedirect, ClientDetails client) throws OAuth2Exception {
-		String redirect = super.resolveRedirect(requestedRedirect, client);
-		if (blacklistService.isBlacklisted(redirect)) {
-			// don't let it go through
-			throw new InvalidRequestException("The supplied redirect_uri is not allowed on this server.");
-		} else {
-			// not blacklisted, passed the parent test, we're fine
-			return redirect;
-		}
-	}
+    @Autowired
+    private BlacklistedSiteService blacklistService;
+
+    /* (non-Javadoc)
+     * @see org.springframework.security.oauth2.provider.endpoint.RedirectResolver#resolveRedirect(java.lang.String, org.springframework.security.oauth2.provider.ClientDetails)
+     */
+    @Override
+    public String resolveRedirect(String requestedRedirect, ClientDetails client) throws OAuth2Exception {
+        String redirect = super.resolveRedirect(requestedRedirect, client);
+        if (blacklistService.isBlacklisted(redirect)) {
+            // don't let it go through
+            throw new InvalidRequestException("The supplied redirect_uri is not allowed on this server.");
+        } else {
+            // not blacklisted, passed the parent test, we're fine
+            return redirect;
+        }
+    }
+
+    protected boolean redirectMatches(String requestedRedirect, String redirectUri) {
+
+        // otherwise do the prefix-match from the library
+        try {
+            URL req = new URL(null, requestedRedirect, new NullURLStreamHandler());
+            URL reg = new URL(null, redirectUri, new NullURLStreamHandler());
+
+            if (reg.getProtocol().equals(req.getProtocol()) && hostMatches(reg.getHost(), req.getHost())) {
+                return StringUtils.cleanPath(req.getPath()).startsWith(StringUtils.cleanPath(reg.getPath()));
+            }
+        } catch (MalformedURLException e) {
+        }
+        return requestedRedirect.equals(redirectUri);
+    }
+
+    /**
+     * Default implementation that extends URLStreamHandler base class to prevent an error
+     * when instanciating an URL object with a scheme different from http, gopher, etc.
+     */
+    private class NullURLStreamHandler extends URLStreamHandler {
+        @Override
+        protected URLConnection openConnection(URL u) throws IOException {
+            return null;
+        }
+    }
 
 }

--- a/openid-connect-server/src/test/java/org/mitre/oauth2/service/impl/BlacklistAwareRedirectResolverTest.java
+++ b/openid-connect-server/src/test/java/org/mitre/oauth2/service/impl/BlacklistAwareRedirectResolverTest.java
@@ -1,0 +1,84 @@
+package org.mitre.oauth2.service.impl;
+
+import com.google.common.collect.Sets;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mitre.oauth2.model.ClientDetailsEntity;
+import org.mitre.openid.connect.service.BlacklistedSiteService;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.security.oauth2.common.exceptions.InvalidRequestException;
+import org.springframework.security.oauth2.common.exceptions.RedirectMismatchException;
+
+import static junit.framework.Assert.assertEquals;
+
+/**
+ * @author r3dlin3
+ */
+
+@RunWith(MockitoJUnitRunner.class)
+public class BlacklistAwareRedirectResolverTest {
+
+    private String blackListUri = "http://blacklist:9000/oauth/";
+    private String standardUrl = "http://localhost:9000/oauth/";
+    private String requestedUrlWithArguments = "http://localhost:9000/oauth/someAction?arg2=321";
+    private String nonStandardUri = "org.mitre://test/";
+    private String requestedUriWithArguments = "org.mitre://test/action?arg1=123&arg2=896";
+    private String missingUri = "http://unknown";
+
+    private ClientDetailsEntity client;
+
+    @InjectMocks
+    BlacklistAwareRedirectResolver resolver = new BlacklistAwareRedirectResolver();
+
+    @Mock
+    private BlacklistedSiteService mockBlacklistedSiteService;
+
+
+
+    @Before
+    public void setUp() throws Exception {
+        Mockito.when(mockBlacklistedSiteService.isBlacklisted(blackListUri)).thenReturn(true);
+        Mockito.when(mockBlacklistedSiteService.isBlacklisted(standardUrl)).thenReturn(false);
+        Mockito.when(mockBlacklistedSiteService.isBlacklisted(nonStandardUri)).thenReturn(false);
+        Mockito.when(mockBlacklistedSiteService.isBlacklisted(missingUri)).thenReturn(false);
+
+        client = new ClientDetailsEntity();
+        client.setClientId("clientId");
+        client.setGrantTypes(Sets.newHashSet("implicit"));
+        client.setRedirectUris(Sets.newHashSet(blackListUri, standardUrl, nonStandardUri));
+    }
+
+    @Test
+    public void testResolveRedirectUrl() throws Exception {
+        String s = resolver.resolveRedirect(standardUrl, client);
+        assertEquals(standardUrl, s);
+
+        s = resolver.resolveRedirect(requestedUrlWithArguments, client);
+        assertEquals(requestedUrlWithArguments, s);
+    }
+
+    @Test
+    public void testResolveRedirectUri() throws Exception {
+        String s = resolver.resolveRedirect(nonStandardUri, client);
+        assertEquals(nonStandardUri,s);
+
+        s = resolver.resolveRedirect(requestedUriWithArguments, client);
+        assertEquals(requestedUriWithArguments, s);
+    }
+
+    @Test(expected = RedirectMismatchException.class)
+    public void testUnknownRedirectUri() throws Exception {
+        String s = resolver.resolveRedirect(missingUri, client);
+
+    }
+
+    @Test(expected = InvalidRequestException.class)
+    public void testBlacklistedRedirectUri() throws Exception {
+        String s = resolver.resolveRedirect(blackListUri, client);
+
+    }
+}


### PR DESCRIPTION
Update in BlacklistAwareRedirectResolver.java to work correctly with non standard scheme (in the case of mobile application for instance) and not fall back on exact match as org.springframework.security.oauth2.provider.endpoint.DefaultRedirectResolver