### PR TITLE
Allow extenders to add additional information to the access token

### DIFF
--- a/openid-connect-common/src/main/java/org/mitre/oauth2/model/OAuth2AccessTokenEntity.java
+++ b/openid-connect-common/src/main/java/org/mitre/oauth2/model/OAuth2AccessTokenEntity.java
@@ -114,6 +114,8 @@ public class OAuth2AccessTokenEntity implements OAuth2AccessToken {
 	private Set<String> scope;
 
 	private Set<Permission> permissions;
+	
+	private Map<String, Object> additionalInformation = new HashMap<>();
 
 	/**
 	 * Create a new, blank access token
@@ -145,11 +147,10 @@ public class OAuth2AccessTokenEntity implements OAuth2AccessToken {
 	@Override
 	@Transient
 	public Map<String, Object> getAdditionalInformation() {
-		Map<String, Object> map = new HashMap<>(); //super.getAdditionalInformation();
 		if (getIdToken() != null) {
-			map.put(ID_TOKEN_FIELD_NAME, getIdTokenString());
+			additionalInformation.put(ID_TOKEN_FIELD_NAME, getIdTokenString());
 		}
-		return map;
+		return additionalInformation;
 	}
 
 	/**

--- a/openid-connect-common/src/main/java/org/mitre/oauth2/model/OAuth2AccessTokenEntity.java
+++ b/openid-connect-common/src/main/java/org/mitre/oauth2/model/OAuth2AccessTokenEntity.java
@@ -150,6 +150,9 @@ public class OAuth2AccessTokenEntity implements OAuth2AccessToken {
 		if (getIdToken() != null) {
 			additionalInformation.put(ID_TOKEN_FIELD_NAME, getIdTokenString());
 		}
+		else if (additionalInformation.containsKey(ID_TOKEN_FIELD_NAME)) {
+			additionalInformation.remove(ID_TOKEN_FIELD_NAME);
+		}
 		return additionalInformation;
 	}
 


### PR DESCRIPTION
While implementing the Session Management spec for MitreID I noticed there was no clean way to provide back with the access token the required claim of `session_state`.  This patch moves the map that was being recreated each time in the `getAdditionalInformation` method up, making it a member of the `OAuth2AccessTokenEntity` so that extenders can can store additional information (like `session_state`) if necessary.