### PR TITLE
apiAddClient return a HttpStatus.Conflict if you try to create a client with a used client id

### DIFF
--- a/openid-connect-server/pom.xml
+++ b/openid-connect-server/pom.xml
@@ -46,6 +46,11 @@
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-tx</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.eclipse.persistence</groupId>
+			<artifactId>org.eclipse.persistence.core</artifactId>
+			<version>2.5.1</version>
+		</dependency>
 
 	</dependencies>
 	<description>OpenID Connect server libraries for Spring and Spring Security.</description>


### PR DESCRIPTION
This makes `apiAddClient` in the client api return `HttpStatus.Conflict` if you try to create a client with a used client id.

This fixes a bug where if you try to create a client with a client id that is already in use, you get an empty error message. Instead, now you get a message that tells you that the client couldn't be created because the client id is already in use.

To reproduce the bug, you can run the application then:

1. Sign in with `admin`/`password`
2. Go to `Manage Clients` and create a `New Client`
3. Set `Client ID` to a value (in my case I set it to `asdf`)
4. `Save` the client
5. Create a `New Client`
6. Set `Client ID` to the value you put in step 2 (`asdf`)
7. Error message is malformed
