### PR TITLE
stats loading performance issue

### DIFF
--- a/openid-connect-common/src/main/java/org/mitre/oauth2/model/ClientDetailsEntity.java
+++ b/openid-connect-common/src/main/java/org/mitre/oauth2/model/ClientDetailsEntity.java
@@ -67,7 +67,9 @@ import com.nimbusds.jose.JWSAlgorithm;
 @Table(name = "client_details")
 @NamedQueries({
 	@NamedQuery(name = "ClientDetailsEntity.findAll", query = "SELECT c FROM ClientDetailsEntity c"),
-	@NamedQuery(name = "ClientDetailsEntity.getByClientId", query = "select c from ClientDetailsEntity c where c.clientId = :clientId")
+	@NamedQuery(name = "ClientDetailsEntity.getByClientId", query = "select c from ClientDetailsEntity c where c.clientId = :clientId"),
+	@NamedQuery(name = "ClientDetailsEntity.getIdByClientId", query = "select c.id from ClientDetailsEntity c where c.clientId = :clientId"),
+	@NamedQuery(name = "ClientDetailsEntity.stats.findAllIds", query = "SELECT c.id, c.clientId FROM ClientDetailsEntity c")
 })
 public class ClientDetailsEntity implements ClientDetails {
 

--- a/openid-connect-common/src/main/java/org/mitre/openid/connect/model/ApprovedSite.java
+++ b/openid-connect-common/src/main/java/org/mitre/openid/connect/model/ApprovedSite.java
@@ -48,7 +48,9 @@ import com.google.common.collect.Sets;
 	@NamedQuery(name = "ApprovedSite.getAll", query = "select a from ApprovedSite a"),
 	@NamedQuery(name = "ApprovedSite.getByUserId", query = "select a from ApprovedSite a where a.userId = :userId"),
 	@NamedQuery(name = "ApprovedSite.getByClientId", query = "select a from ApprovedSite a where a.clientId = :clientId"),
-	@NamedQuery(name = "ApprovedSite.getByClientIdAndUserId", query = "select a from ApprovedSite a where a.clientId = :clientId and a.userId = :userId")
+	@NamedQuery(name = "ApprovedSite.getByClientIdAndUserId", query = "select a from ApprovedSite a where a.clientId = :clientId and a.userId = :userId"),
+	@NamedQuery(name = "ApprovedSite.stats.getAllClientIds", query = "select a.clientId, count(a) from ApprovedSite a group by a.clientId"),
+	@NamedQuery(name = "ApprovedSite.stats.getAllClientIdUserId", query = "select a.clientId, a.userId from ApprovedSite a")
 })
 public class ApprovedSite {
 

--- a/openid-connect-common/src/main/java/org/mitre/openid/connect/model/ApprovedSite.java
+++ b/openid-connect-common/src/main/java/org/mitre/openid/connect/model/ApprovedSite.java
@@ -50,7 +50,7 @@ import com.google.common.collect.Sets;
 	@NamedQuery(name = "ApprovedSite.getByClientId", query = "select a from ApprovedSite a where a.clientId = :clientId"),
 	@NamedQuery(name = "ApprovedSite.getByClientIdAndUserId", query = "select a from ApprovedSite a where a.clientId = :clientId and a.userId = :userId"),
 	@NamedQuery(name = "ApprovedSite.stats.getAllClientIds", query = "select a.clientId, count(a) from ApprovedSite a group by a.clientId"),
-	@NamedQuery(name = "ApprovedSite.stats.getAllClientIdUserId", query = "select a.clientId, a.userId from ApprovedSite a")
+	@NamedQuery(name = "ApprovedSite.stats.getAllClientIdUserId", query = "select a.id, a.clientId, a.userId from ApprovedSite a")
 })
 public class ApprovedSite {
 

--- a/openid-connect-common/src/main/java/org/mitre/openid/connect/repository/StatsRepository.java
+++ b/openid-connect-common/src/main/java/org/mitre/openid/connect/repository/StatsRepository.java
@@ -1,0 +1,37 @@
+package org.mitre.openid.connect.repository;
+
+import java.util.Vector;
+
+/**
+ * Repository that aggregates queries used to compute stats
+ * in a more efficient way.
+ *
+ * @author zanitete
+ *
+ */
+public interface StatsRepository {
+
+	/**
+	 * Return a collection of Object[], one for each ApprovedSite.
+	 * The first element contains the clientId, the second contains the userId.
+	 *
+	 * @return
+	 */
+	Vector<Object[]> getAllApprovedSitesClientIdAndUserId();
+
+	/**
+	 * Return a collection of Object arrays. The first element of each array represents a clientId (String),
+	 * the second is the number of ApprovedSites for that client (Long).
+	 *
+	 * @return
+	 */
+	Vector<Object[]> getAllApprovedSitesClientIdCount();
+
+	/**
+	 * Return a collection of Object[] containing the mapping between
+	 * the client PK (Long) and the clientId (String).
+	 *
+	 * @return
+	 */
+	Vector<Object[]> getAllClientIds();
+}

--- a/openid-connect-common/src/main/java/org/mitre/openid/connect/repository/StatsRepository.java
+++ b/openid-connect-common/src/main/java/org/mitre/openid/connect/repository/StatsRepository.java
@@ -2,6 +2,9 @@ package org.mitre.openid.connect.repository;
 
 import java.util.Collection;
 
+import org.mitre.oauth2.model.ClientDetailsEntity;
+import org.mitre.openid.connect.model.ApprovedSite;
+
 /**
  * Repository that aggregates queries used to compute stats
  * in a more efficient way.
@@ -12,26 +15,101 @@ import java.util.Collection;
 public interface StatsRepository {
 
 	/**
-	 * Return a collection of Object[], one for each ApprovedSite.
-	 * The first element contains the clientId, the second contains the userId.
+	 * Return the subset of ApprovedSite entity fields needed to compute stats.
 	 *
 	 * @return
 	 */
-	Collection<Object[]> getAllApprovedSitesClientIdAndUserId();
+	Collection<ApprovedSiteId> getAllApprovedSitesClientIdAndUserId();
 
 	/**
-	 * Return a collection of Object arrays. The first element of each array represents a clientId (String),
-	 * the second is the number of ApprovedSites for that client (Long).
+	 * Counts the number of ApprovedSites per Client and return the count.
 	 *
 	 * @return
 	 */
-	Collection<Object[]> getAllApprovedSitesClientIdCount();
+	Collection<ApprovedSitePerClientCount> getAllApprovedSitesClientIdCount();
 
 	/**
-	 * Return a collection of Object[] containing the mapping between
-	 * the client PK (Long) and the clientId (String).
+	 * Return the subset of ClientDetailsEntity fields needed to compute stats.
 	 *
 	 * @return
 	 */
-	Collection<Object[]> getAllClientIds();
+	Collection<ClientDetailsEntityId> getAllClientIds();
+
+	/**
+	 * Result of a group by query with elements count.
+	 */
+	class ApprovedSitePerClientCount {
+
+		private final String clientId;
+		private final Long count;
+
+		public ApprovedSitePerClientCount(String clientId, Long count) {
+			this.clientId = clientId;
+			this.count = count;
+		}
+
+		public String getClientId() {
+			return clientId;
+		}
+		public Long getCount() {
+			return count;
+		}
+
+	}
+
+	/**
+	 * Subset of {@link ApprovedSite} entity fields:
+	 * <ul>
+	 *   <li>id</li>
+	 *   <li>clientId</li>
+	 *   <li>userId</li>
+	 *</ul>
+	 */
+	class ApprovedSiteId {
+		private final Long id;
+		private final String clientId;
+		private final String userId;
+
+		public ApprovedSiteId(Long id, String clientId, String userId) {
+			this.id = id;
+			this.clientId = clientId;
+			this.userId = userId;
+		}
+
+		public Long getId() {
+			return id;
+		}
+		public String getClientId() {
+			return clientId;
+		}
+		public String getUserId() {
+			return userId;
+		}
+
+	}
+
+	/**
+	 * Subset of {@link ClientDetailsEntity} entity fields:
+	 * <ul>
+	 *   <li>id</li>
+	 *   <li>clientId</li>
+	 *</ul>
+	 */
+	class ClientDetailsEntityId {
+		private final Long id;
+		private final String clientId;
+
+		public ClientDetailsEntityId(Long id, String clientId) {
+			this.id = id;
+			this.clientId = clientId;
+		}
+
+		public Long getId() {
+			return id;
+		}
+		public String getClientId() {
+			return clientId;
+		}
+
+	}
 }

--- a/openid-connect-common/src/main/java/org/mitre/openid/connect/repository/StatsRepository.java
+++ b/openid-connect-common/src/main/java/org/mitre/openid/connect/repository/StatsRepository.java
@@ -1,6 +1,6 @@
 package org.mitre.openid.connect.repository;
 
-import java.util.Vector;
+import java.util.Collection;
 
 /**
  * Repository that aggregates queries used to compute stats
@@ -17,7 +17,7 @@ public interface StatsRepository {
 	 *
 	 * @return
 	 */
-	Vector<Object[]> getAllApprovedSitesClientIdAndUserId();
+	Collection<Object[]> getAllApprovedSitesClientIdAndUserId();
 
 	/**
 	 * Return a collection of Object arrays. The first element of each array represents a clientId (String),
@@ -25,7 +25,7 @@ public interface StatsRepository {
 	 *
 	 * @return
 	 */
-	Vector<Object[]> getAllApprovedSitesClientIdCount();
+	Collection<Object[]> getAllApprovedSitesClientIdCount();
 
 	/**
 	 * Return a collection of Object[] containing the mapping between
@@ -33,5 +33,5 @@ public interface StatsRepository {
 	 *
 	 * @return
 	 */
-	Vector<Object[]> getAllClientIds();
+	Collection<Object[]> getAllClientIds();
 }

--- a/openid-connect-server/src/main/java/org/mitre/openid/connect/repository/impl/JpaStatsRepository.java
+++ b/openid-connect-server/src/main/java/org/mitre/openid/connect/repository/impl/JpaStatsRepository.java
@@ -1,6 +1,6 @@
 package org.mitre.openid.connect.repository.impl;
 
-import java.util.Vector;
+import java.util.Collection;
 
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
@@ -21,23 +21,23 @@ public class JpaStatsRepository implements StatsRepository {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public Vector<Object[]> getAllApprovedSitesClientIdAndUserId() {
+	public Collection<Object[]> getAllApprovedSitesClientIdAndUserId() {
 		Query query = manager.createNamedQuery("ApprovedSite.stats.getAllClientIdUserId");
-		return (Vector<Object[]>) query.getResultList();
+		return query.getResultList();
 	}
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public Vector<Object[]> getAllApprovedSitesClientIdCount() {
+	public Collection<Object[]> getAllApprovedSitesClientIdCount() {
 		Query query = manager.createNamedQuery("ApprovedSite.stats.getAllClientIds");
-		return (Vector<Object[]>) query.getResultList();
+		return query.getResultList();
 	}
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public Vector<Object[]> getAllClientIds() {
+	public Collection<Object[]> getAllClientIds() {
 		Query query = manager.createNamedQuery("ClientDetailsEntity.stats.findAllIds");
-		return (Vector<Object[]>) query.getResultList();
+		return query.getResultList();
 	}
 
 }

--- a/openid-connect-server/src/main/java/org/mitre/openid/connect/repository/impl/JpaStatsRepository.java
+++ b/openid-connect-server/src/main/java/org/mitre/openid/connect/repository/impl/JpaStatsRepository.java
@@ -25,7 +25,7 @@ public class JpaStatsRepository implements StatsRepository {
 	public Collection<ApprovedSiteId> getAllApprovedSitesClientIdAndUserId() {
 		Query query = manager.createNamedQuery("ApprovedSite.stats.getAllClientIdUserId");
 		Collection<Object[]> result = query.getResultList();
-		Collection<ApprovedSiteId> retList = new ArrayList<>();
+		Collection<ApprovedSiteId> retList = new ArrayList<ApprovedSiteId>();
 		for(Object[] row: result) {
 			retList.add(new ApprovedSiteId((Long) row[0], (String) row[1], (String) row[2]));
 		}
@@ -37,7 +37,7 @@ public class JpaStatsRepository implements StatsRepository {
 	public Collection<ApprovedSitePerClientCount> getAllApprovedSitesClientIdCount() {
 		Query query = manager.createNamedQuery("ApprovedSite.stats.getAllClientIds");
 		Collection<Object[]> result = query.getResultList();
-		Collection<ApprovedSitePerClientCount> retList = new ArrayList<>();
+		Collection<ApprovedSitePerClientCount> retList = new ArrayList<ApprovedSitePerClientCount>();
 		for(Object[] row: result) {
 			retList.add(new ApprovedSitePerClientCount((String) row[0], (Long) row[1]));
 		}
@@ -49,7 +49,7 @@ public class JpaStatsRepository implements StatsRepository {
 	public Collection<ClientDetailsEntityId> getAllClientIds() {
 		Query query = manager.createNamedQuery("ClientDetailsEntity.stats.findAllIds");
 		Collection<Object[]> result = query.getResultList();
-		Collection<ClientDetailsEntityId> retList = new ArrayList<>();
+		Collection<ClientDetailsEntityId> retList = new ArrayList<ClientDetailsEntityId>();
 		for(Object[] row: result) {
 			retList.add(new ClientDetailsEntityId((Long) row[0], (String) row[1]));
 		}

--- a/openid-connect-server/src/main/java/org/mitre/openid/connect/repository/impl/JpaStatsRepository.java
+++ b/openid-connect-server/src/main/java/org/mitre/openid/connect/repository/impl/JpaStatsRepository.java
@@ -1,5 +1,6 @@
 package org.mitre.openid.connect.repository.impl;
 
+import java.util.ArrayList;
 import java.util.Collection;
 
 import javax.persistence.EntityManager;
@@ -21,23 +22,38 @@ public class JpaStatsRepository implements StatsRepository {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public Collection<Object[]> getAllApprovedSitesClientIdAndUserId() {
+	public Collection<ApprovedSiteId> getAllApprovedSitesClientIdAndUserId() {
 		Query query = manager.createNamedQuery("ApprovedSite.stats.getAllClientIdUserId");
-		return query.getResultList();
+		Collection<Object[]> result = query.getResultList();
+		Collection<ApprovedSiteId> retList = new ArrayList<>();
+		for(Object[] row: result) {
+			retList.add(new ApprovedSiteId((Long) row[0], (String) row[1], (String) row[2]));
+		}
+		return retList;
 	}
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public Collection<Object[]> getAllApprovedSitesClientIdCount() {
+	public Collection<ApprovedSitePerClientCount> getAllApprovedSitesClientIdCount() {
 		Query query = manager.createNamedQuery("ApprovedSite.stats.getAllClientIds");
-		return query.getResultList();
+		Collection<Object[]> result = query.getResultList();
+		Collection<ApprovedSitePerClientCount> retList = new ArrayList<>();
+		for(Object[] row: result) {
+			retList.add(new ApprovedSitePerClientCount((String) row[0], (Long) row[1]));
+		}
+		return retList;
 	}
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public Collection<Object[]> getAllClientIds() {
+	public Collection<ClientDetailsEntityId> getAllClientIds() {
 		Query query = manager.createNamedQuery("ClientDetailsEntity.stats.findAllIds");
-		return query.getResultList();
+		Collection<Object[]> result = query.getResultList();
+		Collection<ClientDetailsEntityId> retList = new ArrayList<>();
+		for(Object[] row: result) {
+			retList.add(new ClientDetailsEntityId((Long) row[0], (String) row[1]));
+		}
+		return retList;
 	}
 
 }

--- a/openid-connect-server/src/main/java/org/mitre/openid/connect/repository/impl/JpaStatsRepository.java
+++ b/openid-connect-server/src/main/java/org/mitre/openid/connect/repository/impl/JpaStatsRepository.java
@@ -1,0 +1,43 @@
+package org.mitre.openid.connect.repository.impl;
+
+import java.util.Vector;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.persistence.Query;
+
+import org.mitre.openid.connect.repository.StatsRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * @author zanitete
+ *
+ */
+@Repository
+public class JpaStatsRepository implements StatsRepository {
+
+	@PersistenceContext
+	EntityManager manager;
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public Vector<Object[]> getAllApprovedSitesClientIdAndUserId() {
+		Query query = manager.createNamedQuery("ApprovedSite.stats.getAllClientIdUserId");
+		return (Vector<Object[]>) query.getResultList();
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public Vector<Object[]> getAllApprovedSitesClientIdCount() {
+		Query query = manager.createNamedQuery("ApprovedSite.stats.getAllClientIds");
+		return (Vector<Object[]>) query.getResultList();
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public Vector<Object[]> getAllClientIds() {
+		Query query = manager.createNamedQuery("ClientDetailsEntity.stats.findAllIds");
+		return (Vector<Object[]>) query.getResultList();
+	}
+
+}

--- a/openid-connect-server/src/main/java/org/mitre/openid/connect/service/impl/DefaultStatsService.java
+++ b/openid-connect-server/src/main/java/org/mitre/openid/connect/service/impl/DefaultStatsService.java
@@ -19,11 +19,11 @@
  */
 package org.mitre.openid.connect.service.impl;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.Vector;
 import java.util.concurrent.TimeUnit;
 
 import org.mitre.openid.connect.repository.StatsRepository;
@@ -77,7 +77,7 @@ public class DefaultStatsService implements StatsService {
 	// do the actual computation
 	private Map<String, Integer> computeSummaryStats() {
 		// get all approved sites
-		Vector<Object[]> result = statsRepository.getAllApprovedSitesClientIdAndUserId();
+		Collection<Object[]> result = statsRepository.getAllApprovedSitesClientIdAndUserId();
 
 		// process to find number of unique users and sites
 		Set<String> userIds = new HashSet<String>();
@@ -108,7 +108,7 @@ public class DefaultStatsService implements StatsService {
 		Map<String, Long> clientIdSurrogateKeyMap = getClientIdSurrogateKeyMap();
 
 		// get all approved sites
-		Vector<Object[]> result = statsRepository.getAllApprovedSitesClientIdCount();
+		Collection<Object[]> result = statsRepository.getAllApprovedSitesClientIdCount();
 
 		for(Object[] row: result) {
 			String clientId = (String) row[0];
@@ -135,7 +135,7 @@ public class DefaultStatsService implements StatsService {
 	 */
 	private Map<Long, Integer> getEmptyClientCountMap() {
 		Map<Long, Integer> counts = new HashMap<>();
-		Vector<Object[]> result = statsRepository.getAllClientIds();
+		Collection<Object[]> result = statsRepository.getAllClientIds();
 		for (Object[] client : result) {
 			counts.put((Long) client[0], 0);
 		}
@@ -148,7 +148,7 @@ public class DefaultStatsService implements StatsService {
 	 */
 	private Map<String, Long> getClientIdSurrogateKeyMap() {
 		Map<String, Long> retMap = new HashMap<>();
-		Vector<Object[]> result = statsRepository.getAllClientIds();
+		Collection<Object[]> result = statsRepository.getAllClientIds();
 		for (Object[] client : result) {
 			retMap.put((String) client[1], (Long) client[0]);
 		}

--- a/openid-connect-server/src/main/java/org/mitre/openid/connect/service/impl/DefaultStatsService.java
+++ b/openid-connect-server/src/main/java/org/mitre/openid/connect/service/impl/DefaultStatsService.java
@@ -134,7 +134,7 @@ public class DefaultStatsService implements StatsService {
 	 * @return
 	 */
 	private Map<Long, Integer> getEmptyClientCountMap() {
-		Map<Long, Integer> counts = new HashMap<>();
+		Map<Long, Integer> counts = new HashMap<Long, Integer>();
 		Collection<Object[]> result = statsRepository.getAllClientIds();
 		for (Object[] client : result) {
 			counts.put((Long) client[0], 0);
@@ -147,7 +147,7 @@ public class DefaultStatsService implements StatsService {
 	 * @return
 	 */
 	private Map<String, Long> getClientIdSurrogateKeyMap() {
-		Map<String, Long> retMap = new HashMap<>();
+		Map<String, Long> retMap = new HashMap<String, Long>();
 		Collection<Object[]> result = statsRepository.getAllClientIds();
 		for (Object[] client : result) {
 			retMap.put((String) client[1], (Long) client[0]);

--- a/openid-connect-server/src/test/java/org/mitre/openid/connect/service/impl/TestDefaultStatsService.java
+++ b/openid-connect-server/src/test/java/org/mitre/openid/connect/service/impl/TestDefaultStatsService.java
@@ -28,6 +28,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mitre.openid.connect.model.ApprovedSite;
 import org.mitre.openid.connect.repository.StatsRepository;
+import org.mitre.openid.connect.repository.StatsRepository.ApprovedSiteId;
+import org.mitre.openid.connect.repository.StatsRepository.ApprovedSitePerClientCount;
+import org.mitre.openid.connect.repository.StatsRepository.ClientDetailsEntityId;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -94,22 +97,22 @@ public class TestDefaultStatsService {
 		Mockito.when(ap6.getUserId()).thenReturn(userId1);
 		Mockito.when(ap6.getClientId()).thenReturn(clientId4);
 
-		Collection<Object[]> apList = ImmutableList.of(
-				new Object[] { ap1.getClientId(), ap1.getUserId() },
-				new Object[] { ap2.getClientId(), ap2.getUserId() },
-				new Object[] { ap3.getClientId(), ap3.getUserId() },
-				new Object[] { ap4.getClientId(), ap4.getUserId() }
+		Collection<ApprovedSiteId> apList = ImmutableList.of(
+				new ApprovedSiteId(1L, ap1.getClientId(), ap1.getUserId()),
+				new ApprovedSiteId(2L, ap2.getClientId(), ap2.getUserId()),
+				new ApprovedSiteId(3L, ap3.getClientId(), ap3.getUserId()),
+				new ApprovedSiteId(4L, ap4.getClientId(), ap4.getUserId())
 				);
-		Collection<Object[]> apCount = ImmutableList.of(
-				new Object[] { clientId1, 2L },
-				new Object[] { clientId2, 1L },
-				new Object[] { clientId3, 1L }
+		Collection<ApprovedSitePerClientCount> apCount = ImmutableList.of(
+				new ApprovedSitePerClientCount(clientId1, 2L),
+				new ApprovedSitePerClientCount(clientId2, 1L),
+				new ApprovedSitePerClientCount(clientId3, 1L)
 				);
-		Collection<Object[]> clientList = ImmutableList.of(
-				new Object[] { 1L, clientId1 },
-				new Object[] { 2L, clientId2 },
-				new Object[] { 3L, clientId3 },
-				new Object[] { 4L, clientId4 }
+		Collection<ClientDetailsEntityId> clientList = ImmutableList.of(
+				new ClientDetailsEntityId(1L, clientId1),
+				new ClientDetailsEntityId(2L, clientId2),
+				new ClientDetailsEntityId(3L, clientId3),
+				new ClientDetailsEntityId(4L, clientId4)
 				);
 
 		Mockito.when(statsRepository.getAllApprovedSitesClientIdAndUserId()).thenReturn(apList);
@@ -120,7 +123,7 @@ public class TestDefaultStatsService {
 	@Test
 	public void calculateSummaryStats_empty() {
 
-		Mockito.when(statsRepository.getAllApprovedSitesClientIdAndUserId()).thenReturn(new Vector<Object[]>());
+		Mockito.when(statsRepository.getAllApprovedSitesClientIdAndUserId()).thenReturn(new Vector<ApprovedSiteId>());
 
 		Map<String, Integer> stats = service.getSummaryStats();
 
@@ -141,7 +144,7 @@ public class TestDefaultStatsService {
 	@Test
 	public void calculateByClientId_empty() {
 
-		Mockito.when(statsRepository.getAllApprovedSitesClientIdCount()).thenReturn(new Vector<Object[]>());
+		Mockito.when(statsRepository.getAllApprovedSitesClientIdCount()).thenReturn(new Vector<ApprovedSitePerClientCount>());
 
 		Map<Long, Integer> stats = service.getByClientId();
 
@@ -180,13 +183,13 @@ public class TestDefaultStatsService {
 		assertThat(stats.get("userCount"), is(2));
 		assertThat(stats.get("clientCount"), is(3));
 
-		Collection<Object[]> newList = ImmutableList.of(
-				new Object[] { ap1.getClientId(), ap1.getUserId() },
-				new Object[] { ap2.getClientId(), ap2.getUserId() },
-				new Object[] { ap3.getClientId(), ap3.getUserId() },
-				new Object[] { ap4.getClientId(), ap4.getUserId() },
-				new Object[] { ap5.getClientId(), ap5.getUserId() },
-				new Object[] { ap6.getClientId(), ap6.getUserId() }
+		Collection<ApprovedSiteId> newList = ImmutableList.of(
+				new ApprovedSiteId(1L, ap1.getClientId(), ap1.getUserId()),
+				new ApprovedSiteId(2L, ap2.getClientId(), ap2.getUserId()),
+				new ApprovedSiteId(3L, ap3.getClientId(), ap3.getUserId()),
+				new ApprovedSiteId(4L, ap4.getClientId(), ap4.getUserId()),
+				new ApprovedSiteId(5L, ap5.getClientId(), ap5.getUserId()),
+				new ApprovedSiteId(6L, ap6.getClientId(), ap6.getUserId())
 				);
 
 		Mockito.when(statsRepository.getAllApprovedSitesClientIdAndUserId()).thenReturn(newList);

--- a/openid-connect-server/src/test/java/org/mitre/openid/connect/service/impl/TestDefaultStatsService.java
+++ b/openid-connect-server/src/test/java/org/mitre/openid/connect/service/impl/TestDefaultStatsService.java
@@ -19,6 +19,7 @@ package org.mitre.openid.connect.service.impl;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
+import java.util.Collection;
 import java.util.Map;
 import java.util.Vector;
 
@@ -93,23 +94,23 @@ public class TestDefaultStatsService {
 		Mockito.when(ap6.getUserId()).thenReturn(userId1);
 		Mockito.when(ap6.getClientId()).thenReturn(clientId4);
 
-		Vector<Object[]> apList = new Vector<>(ImmutableList.of(
+		Collection<Object[]> apList = ImmutableList.of(
 				new Object[] { ap1.getClientId(), ap1.getUserId() },
 				new Object[] { ap2.getClientId(), ap2.getUserId() },
 				new Object[] { ap3.getClientId(), ap3.getUserId() },
 				new Object[] { ap4.getClientId(), ap4.getUserId() }
-				));
-		Vector<Object[]> apCount = new Vector<Object[]> (ImmutableList.of(
+				);
+		Collection<Object[]> apCount = ImmutableList.of(
 				new Object[] { clientId1, 2L },
 				new Object[] { clientId2, 1L },
 				new Object[] { clientId3, 1L }
-				));
-		Vector<Object[]> clientList = new Vector<>(ImmutableList.of(
+				);
+		Collection<Object[]> clientList = ImmutableList.of(
 				new Object[] { 1L, clientId1 },
 				new Object[] { 2L, clientId2 },
 				new Object[] { 3L, clientId3 },
 				new Object[] { 4L, clientId4 }
-				));
+				);
 
 		Mockito.when(statsRepository.getAllApprovedSitesClientIdAndUserId()).thenReturn(apList);
 		Mockito.when(statsRepository.getAllApprovedSitesClientIdCount()).thenReturn(apCount);
@@ -179,14 +180,14 @@ public class TestDefaultStatsService {
 		assertThat(stats.get("userCount"), is(2));
 		assertThat(stats.get("clientCount"), is(3));
 
-		Vector<Object[]> newList = new Vector<Object[]>(ImmutableList.of(
+		Collection<Object[]> newList = ImmutableList.of(
 				new Object[] { ap1.getClientId(), ap1.getUserId() },
 				new Object[] { ap2.getClientId(), ap2.getUserId() },
 				new Object[] { ap3.getClientId(), ap3.getUserId() },
 				new Object[] { ap4.getClientId(), ap4.getUserId() },
 				new Object[] { ap5.getClientId(), ap5.getUserId() },
 				new Object[] { ap6.getClientId(), ap6.getUserId() }
-				));
+				);
 
 		Mockito.when(statsRepository.getAllApprovedSitesClientIdAndUserId()).thenReturn(newList);
 		Map<String, Integer> stats2 = service.getSummaryStats();


### PR DESCRIPTION
This will increase considerably the performance of the stats loading by executing dedicated queries instead of loading the whole entities ApprovedSite and ClientDetailsEntity. It affects many views including:
- site approval page
- client config page
