### PR TITLE
Fix form action for approve.jsp for root contexts

### DIFF
--- a/openid-connect-server-webapp/src/main/webapp/WEB-INF/views/approve.jsp
+++ b/openid-connect-server-webapp/src/main/webapp/WEB-INF/views/approve.jsp
@@ -36,7 +36,7 @@
 		</h1>
 
 		<form name="confirmationForm"
-			action="<%=request.getContextPath()%>/authorize" method="post">
+			action="${request.getContextPath().endsWith('/') ? request.getContextPath() : request.getContextPath().concat('/') }authorize" method="post">
 
 			<div class="row">
 				<div class="span5 offset1 well-small" style="text-align: left">

--- a/openid-connect-server-webapp/src/main/webapp/WEB-INF/views/approve.jsp
+++ b/openid-connect-server-webapp/src/main/webapp/WEB-INF/views/approve.jsp
@@ -36,7 +36,7 @@
 		</h1>
 
 		<form name="confirmationForm"
-			action="${request.getContextPath().endsWith('/') ? request.getContextPath() : request.getContextPath().concat('/') }authorize" method="post">
+			action="${pageContext.request.contextPath.endsWith('/') ? pageContext.request.contextPath : pageContext.request.contextPath.concat('/') }authorize" method="post">
 
 			<div class="row">
 				<div class="span5 offset1 well-small" style="text-align: left">


### PR DESCRIPTION
The current code produces `action="//approve"` for root contexts which will brake the application.