### PR TITLE
Changed from SimpleGrantedAuthority to GrantedAuthority. Suggested fix to #1040

### DIFF
--- a/openid-connect-common/src/main/java/org/mitre/oauth2/model/convert/SimpleGrantedAuthorityStringConverter.java
+++ b/openid-connect-common/src/main/java/org/mitre/oauth2/model/convert/SimpleGrantedAuthorityStringConverter.java
@@ -20,17 +20,21 @@ package org.mitre.oauth2.model.convert;
 import javax.persistence.AttributeConverter;
 import javax.persistence.Converter;
 
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author jricher
  *
  */
 @Converter
-public class SimpleGrantedAuthorityStringConverter implements AttributeConverter<SimpleGrantedAuthority, String> {
+public class SimpleGrantedAuthorityStringConverter implements AttributeConverter<GrantedAuthority, String> {
 
 	@Override
-	public String convertToDatabaseColumn(SimpleGrantedAuthority attribute) {
+	public String convertToDatabaseColumn(GrantedAuthority attribute) {
 		if (attribute != null) {
 			return attribute.getAuthority();
 		} else {
@@ -39,7 +43,7 @@ public class SimpleGrantedAuthorityStringConverter implements AttributeConverter
 	}
 
 	@Override
-	public SimpleGrantedAuthority convertToEntityAttribute(String dbData) {
+	public GrantedAuthority convertToEntityAttribute(String dbData) {
 		if (dbData != null) {
 			return new SimpleGrantedAuthority(dbData);
 		} else {

--- a/openid-connect-common/src/main/java/org/mitre/oauth2/model/convert/SimpleGrantedAuthorityStringConverter.java
+++ b/openid-connect-common/src/main/java/org/mitre/oauth2/model/convert/SimpleGrantedAuthorityStringConverter.java
@@ -23,8 +23,6 @@ import javax.persistence.Converter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * @author jricher


### PR DESCRIPTION
As suggested in issue #1040 I have submitted a pull request where I've changed from simpleGrantedAuthority to GrantedAuthority in the SimpleGrantedAuthorityStringConverter class. I guess given that the SimpleGrantedAuthorityStringConverter class has this name, one could also change the class name and refering files, but I haven't done this. 

This is my first pull request ever, so I hope it works. But don't feel obliged to accept it, it's a suggestion more than a definitive solution. But it does solve my problem here with the cast exception. 