### PR TITLE
Log response body if one exists

### DIFF
--- a/openid-connect-client/src/main/java/org/mitre/openid/connect/client/OIDCAuthenticationFilter.java
+++ b/openid-connect-client/src/main/java/org/mitre/openid/connect/client/OIDCAuthenticationFilter.java
@@ -415,6 +415,10 @@ public class OIDCAuthenticationFilter extends AbstractAuthenticationProcessingFi
 			// Handle error
 
 			logger.error("Token Endpoint error response:  " + e.getMessage());
+			
+			if (e instanceof HttpClientErrorException) {
+				logger.debug("Token Endpoint message body: " + ((HttpClientErrorException) e).getResponseBodyAsString());
+			}
 
 			throw new AuthenticationServiceException("Unable to obtain Access Token: " + e.getMessage());
 		}


### PR DESCRIPTION
If the OpenID Connect server returns an invalid client error, you can't find that in the logging (because the real error is only visible in the response body).

Logged error:
`HTTP Status 401 - Authentication Failed: Unable to obtain Access Token: 401 Unauthorized`

Non logged error:
`{"error_description":"Client authentication failed: Invalid authentication","error":"invalid_client"}`