### PR TITLE
fix issue #1058: allow auto-detect client-side locale

### DIFF
--- a/openid-connect-server-webapp/src/main/webapp/WEB-INF/application-context.xml
+++ b/openid-connect-server-webapp/src/main/webapp/WEB-INF/application-context.xml
@@ -203,6 +203,9 @@
 		<property name="useCodeAsDefaultMessage" value="true" />
 	</bean>
 
+	<bean id="localeResolver" class="org.springframework.web.servlet.i18n.SessionLocaleResolver">
+	</bean>
+
 	<!-- user services -->
 	<import resource="user-context.xml" />
 


### PR DESCRIPTION
add Spring locale resolver to allow OIDC server auto-detect browser's language options.