### PR TITLE
Set encoding utf-8 for application/json response.

### DIFF
--- a/openid-connect-server/src/main/java/org/mitre/openid/connect/view/JsonEntityView.java
+++ b/openid-connect-server/src/main/java/org/mitre/openid/connect/view/JsonEntityView.java
@@ -82,6 +82,7 @@ public class JsonEntityView extends AbstractView {
 	protected void renderMergedOutputModel(Map<String, Object> model, HttpServletRequest request, HttpServletResponse response) {
 
 		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+		response.setCharacterEncoding("UTF-8");
 
 
 		HttpStatus code = (HttpStatus) model.get(HttpCodeView.CODE);


### PR DESCRIPTION
We really should specify an encoding here and not depend on the
servers default encoding, shouldn't we? It becomes ISO-8859-1
otherwise in Tomcat as per the Servlet specification.