### PR TITLE
Fix version range for bcprov-jdk15on dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -480,7 +480,7 @@
 			<dependency>
 			    <groupId>org.bouncycastle</groupId>
 			    <artifactId>bcprov-jdk15on</artifactId>
-			    <version>[1.52,]</version>
+			    <version>[1.52,)</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>


### PR DESCRIPTION
The version range for org.bouncycastle:bcprov-jdk15on was specified incorrectly.
This caused my gradle build to fail when using org.mitre:openid-connect-client:1.2.6 as a dependency.

See version range specification here: http://maven.apache.org/enforcer/enforcer-rules/versionRanges.html