### PR TITLE
shortTopbarTitle

### DIFF
--- a/openid-connect-common/src/main/java/org/mitre/openid/connect/config/ConfigurationPropertiesBean.java
+++ b/openid-connect-common/src/main/java/org/mitre/openid/connect/config/ConfigurationPropertiesBean.java
@@ -49,6 +49,8 @@ public class ConfigurationPropertiesBean {
 	private String issuer;
 
 	private String topbarTitle;
+	
+	private String shortTopbarTitle;
 
 	private String logoImageUrl;
 
@@ -117,6 +119,17 @@ public class ConfigurationPropertiesBean {
 	 */
 	public void setTopbarTitle(String topbarTitle) {
 		this.topbarTitle = topbarTitle;
+	}
+	
+	/**
+	 * @return If shortTopbarTitle is undefined, returns topbarTitle. 
+	 */
+	public String getShortTopbarTitle() {
+		return shortTopbarTitle == null ? topbarTitle : shortTopbarTitle;
+	}
+	
+	public void setShortTopbarTitle(String shortTopbarTitle) {
+		this.shortTopbarTitle = shortTopbarTitle;
 	}
 
 	/**

--- a/openid-connect-common/src/test/java/org/mitre/openid/connect/config/ConfigurationPropertiesBeanTest.java
+++ b/openid-connect-common/src/test/java/org/mitre/openid/connect/config/ConfigurationPropertiesBeanTest.java
@@ -134,5 +134,14 @@ public class ConfigurationPropertiesBeanTest {
 		}
 
 	}
+	
+	@Test
+	public void testShortTopbarTitle() {
+		ConfigurationPropertiesBean bean = new ConfigurationPropertiesBean();
+		bean.setTopbarTitle("LONG");
+		assertEquals("LONG", bean.getShortTopbarTitle());
+		bean.setShortTopbarTitle("SHORT");
+		assertEquals("SHORT", bean.getShortTopbarTitle());
+	}
 
 }

--- a/openid-connect-server-webapp/src/main/webapp/WEB-INF/tags/topbar.tag
+++ b/openid-connect-server-webapp/src/main/webapp/WEB-INF/tags/topbar.tag
@@ -34,7 +34,13 @@
 				<span class="icon-bar"></span> 
 				<span class="icon-bar"></span>
 			</button>
-			<a class="brand" href=""><img src="${ config.logoImageUrl }" /> ${config.topbarTitle}</a>
+			<a class="brand" href="">
+				<img src="${ config.logoImageUrl }" />
+				<span>
+					<span class="visible-phone">${config.shortTopbarTitle}</span> 
+					<span class="hidden-phone">${config.topbarTitle}</span>
+				</span>
+			</a>
 			<c:if test="${ not empty pageName }">
 				<div class="nav-collapse collapse">
 					<ul class="nav">


### PR DESCRIPTION
Currently, if topbar title is very long, it does not fit nicely on phones. This PR enables one to define a shortTopbarTitle in config, which will replace topbarTitle on phones. This shortTopbarTitle defaults to topbarTitle if undefined, so the change is backward-compatible.