### PR TITLE
DefaultOAuth2AuthorizationCodeService.createAuthorizationCode should be @Transactional

### DIFF
--- a/openid-connect-server/src/main/java/org/mitre/oauth2/service/impl/DefaultOAuth2AuthorizationCodeService.java
+++ b/openid-connect-server/src/main/java/org/mitre/oauth2/service/impl/DefaultOAuth2AuthorizationCodeService.java
@@ -66,6 +66,7 @@ public class DefaultOAuth2AuthorizationCodeService implements AuthorizationCodeS
 	 * @return 					the authorization code
 	 */
 	@Override
+	@Transactional(value="defaultTransactionManager")
 	public String createAuthorizationCode(OAuth2Authentication authentication) {
 		String code = generator.generate();
 


### PR DESCRIPTION
An Authentication should not exist without its matching AuthorizationCode, but typically an AuthorizationCode will have a foreign key on an Authentication, meaning it can't be saved first. This block should be wrapped in a transaction so that other DB clients don't see an inconsistent snapshot and then misbehave.

In particular, the cleanup job in DefaultOAuth2ProviderTokenService.clearExpiredTokens can cause data corruption. This may be what was experienced in #982.
