### PR TITLE
rp jdk6 compatibility

### DIFF
--- a/openid-connect-client/pom.xml
+++ b/openid-connect-client/pom.xml
@@ -24,6 +24,9 @@
 		<version>1.2.7-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
+	<properties>
+		<maven.javadoc.skip>true</maven.javadoc.skip>
+	</properties>
 	<artifactId>openid-connect-client</artifactId>
 	<description>OpenID Connect Client filter for Spring Security</description>
 	<name>OpenID Connect Client</name>
@@ -31,6 +34,32 @@
 		<dependency>
 			<groupId>org.mitre</groupId>
 			<artifactId>openid-connect-common</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpclient</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.google.code.gson</groupId>
+			<artifactId>gson</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.nimbusds</groupId>
+			<artifactId>nimbus-jose-jwt</artifactId>
+			<classifier>jdk16</classifier>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.security.oauth</groupId>
+			<artifactId>spring-security-oauth2</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<scope>provided</scope>
 		</dependency>
 	</dependencies>
 	<packaging>jar</packaging>
@@ -41,7 +70,7 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
 					<source>${java-version}</source>
-					<target>${java-version}</target>
+					<target>${java-compile}</target>
 				</configuration>
 			</plugin>
 			<!-- BUILD SOURCE FILES -->
@@ -53,19 +82,6 @@
 						<id>attach-sources</id>
 						<goals>
 							<goal>jar-no-fork</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<!-- BUILD JavaDoc FILES -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-javadoc-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>attach-sources</id>
-						<goals>
-							<goal>jar</goal>
 						</goals>
 					</execution>
 				</executions>

--- a/openid-connect-client/src/main/java/org/mitre/oauth2/introspectingfilter/IntrospectingTokenService.java
+++ b/openid-connect-client/src/main/java/org/mitre/oauth2/introspectingfilter/IntrospectingTokenService.java
@@ -101,7 +101,7 @@ public class IntrospectingTokenService implements ResourceServerTokenServices {
 		}
 	}
 
-	private Map<String, TokenCacheObject> authCache = new HashMap<>();
+	private Map<String, TokenCacheObject> authCache = new HashMap<String, TokenCacheObject>();
 	/**
 	 * Logger for this class
 	 */
@@ -224,11 +224,11 @@ public class IntrospectingTokenService implements ResourceServerTokenServices {
 
 	private OAuth2Request createStoredRequest(final JsonObject token) {
 		String clientId = token.get("client_id").getAsString();
-		Set<String> scopes = new HashSet<>();
+		Set<String> scopes = new HashSet<String>();
 		if (token.has("scope")) {
 			scopes.addAll(OAuth2Utils.parseParameterList(token.get("scope").getAsString()));
 		}
-		Map<String, String> parameters = new HashMap<>();
+		Map<String, String> parameters = new HashMap<String, String>();
 		parameters.put("client_id", clientId);
 		parameters.put("scope", OAuth2Utils.formatParameterList(scopes));
 		OAuth2Request storedRequest = new OAuth2Request(parameters, clientId, null, true, scopes, null, null, null, null);
@@ -268,7 +268,7 @@ public class IntrospectingTokenService implements ResourceServerTokenServices {
 		String validatedToken = null;
 
 		RestTemplate restTemplate;
-		MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
+		MultiValueMap<String, String> form = new LinkedMultiValueMap<String, String>();
 
 		final String clientId = client.getClientId();
 		final String clientSecret = client.getClientSecret();

--- a/openid-connect-client/src/main/java/org/mitre/oauth2/introspectingfilter/OAuth2AccessTokenImpl.java
+++ b/openid-connect-client/src/main/java/org/mitre/oauth2/introspectingfilter/OAuth2AccessTokenImpl.java
@@ -34,7 +34,7 @@ public class OAuth2AccessTokenImpl implements OAuth2AccessToken {
 
 	private JsonObject introspectionResponse;
 	private String tokenString;
-	private Set<String> scopes = new HashSet<>();
+	private Set<String> scopes = new HashSet<String>();
 	private Date expireDate;
 
 

--- a/openid-connect-client/src/main/java/org/mitre/oauth2/introspectingfilter/service/impl/ScopeBasedIntrospectionAuthoritiesGranter.java
+++ b/openid-connect-client/src/main/java/org/mitre/oauth2/introspectingfilter/service/impl/ScopeBasedIntrospectionAuthoritiesGranter.java
@@ -42,7 +42,7 @@ public class ScopeBasedIntrospectionAuthoritiesGranter implements IntrospectionA
 	 */
 	@Override
 	public List<GrantedAuthority> getAuthorities(JsonObject introspectionResponse) {
-		List<GrantedAuthority> auth = new ArrayList<>(getAuthorities());
+		List<GrantedAuthority> auth = new ArrayList<GrantedAuthority>(getAuthorities());
 		
 		if (introspectionResponse.has("scope") && introspectionResponse.get("scope").isJsonPrimitive()) {
 			String scopeString = introspectionResponse.get("scope").getAsString();

--- a/openid-connect-client/src/main/java/org/mitre/openid/connect/client/NamedAdminAuthoritiesMapper.java
+++ b/openid-connect-client/src/main/java/org/mitre/openid/connect/client/NamedAdminAuthoritiesMapper.java
@@ -49,12 +49,12 @@ public class NamedAdminAuthoritiesMapper implements OIDCAuthoritiesMapper {
 	private static final SimpleGrantedAuthority ROLE_ADMIN = new SimpleGrantedAuthority("ROLE_ADMIN");
 	private static final SimpleGrantedAuthority ROLE_USER = new SimpleGrantedAuthority("ROLE_USER");
 
-	private Set<SubjectIssuerGrantedAuthority> admins = new HashSet<>();
+	private Set<SubjectIssuerGrantedAuthority> admins = new HashSet<SubjectIssuerGrantedAuthority>();
 
 	@Override
 	public Collection<? extends GrantedAuthority> mapAuthorities(JWT idToken, UserInfo userInfo) {
 
-		Set<GrantedAuthority> out = new HashSet<>();
+		Set<GrantedAuthority> out = new HashSet<GrantedAuthority>();
 		try {
 			JWTClaimsSet claims = idToken.getJWTClaimsSet();
 

--- a/openid-connect-client/src/main/java/org/mitre/openid/connect/client/OIDCAuthenticationFilter.java
+++ b/openid-connect-client/src/main/java/org/mitre/openid/connect/client/OIDCAuthenticationFilter.java
@@ -298,7 +298,7 @@ public class OIDCAuthenticationFilter extends AbstractAuthenticationProcessingFi
 		ServerConfiguration serverConfig = servers.getServerConfiguration(issuer);
 		final RegisteredClient clientConfig = clients.getClientConfiguration(serverConfig);
 
-		MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
+		MultiValueMap<String, String> form = new LinkedMultiValueMap<String, String>();
 		form.add("grant_type", "authorization_code");
 		form.add("code", authorizationCode);
 		form.setAll(authOptions.getTokenOptions(serverConfig, clientConfig, request));

--- a/openid-connect-client/src/main/java/org/mitre/openid/connect/client/UserInfoFetcher.java
+++ b/openid-connect-client/src/main/java/org/mitre/openid/connect/client/UserInfoFetcher.java
@@ -70,7 +70,10 @@ public class UserInfoFetcher {
 	public UserInfo loadUserInfo(final PendingOIDCAuthenticationToken token) {
 		try {
 			return cache.get(token);
-		} catch (UncheckedExecutionException | ExecutionException e) {
+		} catch (ExecutionException e) {
+			logger.warn("Couldn't load User Info from token: " + e.getMessage());
+			return null;
+		} catch (UncheckedExecutionException e) {
 			logger.warn("Couldn't load User Info from token: " + e.getMessage());
 			return null;
 		}
@@ -116,7 +119,7 @@ public class UserInfoFetcher {
 					userInfoString = restTemplate.getForObject(serverConfiguration.getUserInfoUri(), String.class);
 	
 				} else if (serverConfiguration.getUserInfoTokenMethod().equals(UserInfoTokenMethod.FORM)) {
-					MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
+					MultiValueMap<String, String> form = new LinkedMultiValueMap<String, String>();
 					form.add("access_token", token.getAccessTokenValue());
 	
 					RestTemplate restTemplate = new RestTemplate(factory);

--- a/openid-connect-client/src/main/java/org/mitre/openid/connect/client/service/impl/DynamicRegistrationClientConfigurationService.java
+++ b/openid-connect-client/src/main/java/org/mitre/openid/connect/client/service/impl/DynamicRegistrationClientConfigurationService.java
@@ -68,8 +68,8 @@ public class DynamicRegistrationClientConfigurationService implements ClientConf
 
 	private RegisteredClient template;
 
-	private Set<String> whitelist = new HashSet<>();
-	private Set<String> blacklist = new HashSet<>();
+	private Set<String> whitelist = new HashSet<String>();
+	private Set<String> blacklist = new HashSet<String>();
 
 	public DynamicRegistrationClientConfigurationService() {
 		clients = CacheBuilder.newBuilder().build(new DynamicClientRegistrationLoader());
@@ -87,7 +87,10 @@ public class DynamicRegistrationClientConfigurationService implements ClientConf
 			}
 
 			return clients.get(issuer);
-		} catch (UncheckedExecutionException | ExecutionException e) {
+		} catch (ExecutionException e) {
+			logger.warn("Unable to get client configuration", e);
+			return null;
+		} catch (UncheckedExecutionException e) {
 			logger.warn("Unable to get client configuration", e);
 			return null;
 		}
@@ -191,7 +194,7 @@ public class DynamicRegistrationClientConfigurationService implements ClientConf
 				headers.setContentType(MediaType.APPLICATION_JSON);
 				headers.setAccept(Lists.newArrayList(MediaType.APPLICATION_JSON));
 
-				HttpEntity<String> entity = new HttpEntity<>(serializedClient, headers);
+				HttpEntity<String> entity = new HttpEntity<String>(serializedClient, headers);
 
 				try {
 					String registered = restTemplate.postForObject(serverConfig.getRegistrationEndpointUri(), entity, String.class);
@@ -214,7 +217,7 @@ public class DynamicRegistrationClientConfigurationService implements ClientConf
 					headers.set("Authorization", String.format("%s %s", OAuth2AccessToken.BEARER_TYPE, knownClient.getRegistrationAccessToken()));
 					headers.setAccept(Lists.newArrayList(MediaType.APPLICATION_JSON));
 
-					HttpEntity<String> entity = new HttpEntity<>(headers);
+					HttpEntity<String> entity = new HttpEntity<String>(headers);
 
 					try {
 						String registered = restTemplate.exchange(knownClient.getRegistrationClientUri(), HttpMethod.GET, entity, String.class).getBody();

--- a/openid-connect-client/src/main/java/org/mitre/openid/connect/client/service/impl/DynamicServerConfigurationService.java
+++ b/openid-connect-client/src/main/java/org/mitre/openid/connect/client/service/impl/DynamicServerConfigurationService.java
@@ -65,8 +65,8 @@ public class DynamicServerConfigurationService implements ServerConfigurationSer
 	// map of issuer -> server configuration, loaded dynamically from service discovery
 	private LoadingCache<String, ServerConfiguration> servers;
 
-	private Set<String> whitelist = new HashSet<>();
-	private Set<String> blacklist = new HashSet<>();
+	private Set<String> whitelist = new HashSet<String>();
+	private Set<String> blacklist = new HashSet<String>();
 
 	public DynamicServerConfigurationService() {
 		// initialize the cache
@@ -114,7 +114,10 @@ public class DynamicServerConfigurationService implements ServerConfigurationSer
 			}
 
 			return servers.get(issuer);
-		} catch (UncheckedExecutionException | ExecutionException e) {
+		} catch (ExecutionException e) {
+			logger.warn("Couldn't load configuration for " + issuer + ": " + e);
+			return null;
+		} catch (UncheckedExecutionException e) {
 			logger.warn("Couldn't load configuration for " + issuer + ": " + e);
 			return null;
 		}

--- a/openid-connect-client/src/main/java/org/mitre/openid/connect/client/service/impl/InMemoryRegisteredClientService.java
+++ b/openid-connect-client/src/main/java/org/mitre/openid/connect/client/service/impl/InMemoryRegisteredClientService.java
@@ -31,7 +31,7 @@ import org.mitre.openid.connect.client.service.RegisteredClientService;
  */
 public class InMemoryRegisteredClientService implements RegisteredClientService {
 
-	private Map<String, RegisteredClient> clients = new HashMap<>();
+	private Map<String, RegisteredClient> clients = new HashMap<String, RegisteredClient>();
 
 	/* (non-Javadoc)
 	 * @see org.mitre.openid.connect.client.service.RegisteredClientService#getByIssuer(java.lang.String)

--- a/openid-connect-client/src/main/java/org/mitre/openid/connect/client/service/impl/JsonFileRegisteredClientService.java
+++ b/openid-connect-client/src/main/java/org/mitre/openid/connect/client/service/impl/JsonFileRegisteredClientService.java
@@ -72,7 +72,7 @@ public class JsonFileRegisteredClientService implements RegisteredClientService 
 
 	private File file;
 
-	private Map<String, RegisteredClient> clients = new HashMap<>();
+	private Map<String, RegisteredClient> clients = new HashMap<String, RegisteredClient>();
 
 	public JsonFileRegisteredClientService(String filename) {
 		this.file = new File(filename);

--- a/openid-connect-client/src/main/java/org/mitre/openid/connect/client/service/impl/StaticAuthRequestOptionsService.java
+++ b/openid-connect-client/src/main/java/org/mitre/openid/connect/client/service/impl/StaticAuthRequestOptionsService.java
@@ -37,8 +37,8 @@ import org.mitre.openid.connect.config.ServerConfiguration;
  */
 public class StaticAuthRequestOptionsService implements AuthRequestOptionsService {
 
-	private Map<String, String> options = new HashMap<>();
-	private Map<String, String> tokenOptions = new HashMap<>();
+	private Map<String, String> options = new HashMap<String, String>();
+	private Map<String, String> tokenOptions = new HashMap<String, String>();
 
 	/* (non-Javadoc)
 	 * @see org.mitre.openid.connect.client.service.AuthRequestOptionsService#getOptions(org.mitre.openid.connect.config.ServerConfiguration, org.mitre.oauth2.model.RegisteredClient, javax.servlet.http.HttpServletRequest)

--- a/openid-connect-client/src/main/java/org/mitre/openid/connect/client/service/impl/ThirdPartyIssuerService.java
+++ b/openid-connect-client/src/main/java/org/mitre/openid/connect/client/service/impl/ThirdPartyIssuerService.java
@@ -44,8 +44,8 @@ public class ThirdPartyIssuerService implements IssuerService {
 
 	private String accountChooserUrl;
 
-	private Set<String> whitelist = new HashSet<>();
-	private Set<String> blacklist = new HashSet<>();
+	private Set<String> whitelist = new HashSet<String>();
+	private Set<String> blacklist = new HashSet<String>();
 
 	/* (non-Javadoc)
 	 * @see org.mitre.openid.connect.client.service.IssuerService#getIssuer(javax.servlet.http.HttpServletRequest)

--- a/openid-connect-client/src/main/java/org/mitre/openid/connect/client/service/impl/WebfingerIssuerService.java
+++ b/openid-connect-client/src/main/java/org/mitre/openid/connect/client/service/impl/WebfingerIssuerService.java
@@ -75,8 +75,8 @@ public class WebfingerIssuerService implements IssuerService {
 		}
 	}
 	
-	private Set<String> whitelist = new HashSet<>();
-	private Set<String> blacklist = new HashSet<>();
+	private Set<String> whitelist = new HashSet<String>();
+	private Set<String> blacklist = new HashSet<String>();
 
 	/**
 	 * Name of the incoming parameter to check for discovery purposes.
@@ -116,7 +116,10 @@ public class WebfingerIssuerService implements IssuerService {
 				}
 
 				return new IssuerServiceResponse(lr.issuer, lr.loginHint, null);
-			} catch (UncheckedExecutionException | ExecutionException e) {
+			} catch (ExecutionException e) {
+				logger.warn("Issue fetching issuer for user input: " + identifier + ": " + e.getMessage());
+				return null;
+			} catch (UncheckedExecutionException e) {
 				logger.warn("Issue fetching issuer for user input: " + identifier + ": " + e.getMessage());
 				return null;
 			}
@@ -276,7 +279,9 @@ public class WebfingerIssuerService implements IssuerService {
 						}
 					}
 				}
-			} catch (JsonParseException | RestClientException e) {
+			} catch (RestClientException e) {
+				logger.warn("Failure in fetching webfinger input", e.getMessage());
+			} catch (JsonParseException e) {
 				logger.warn("Failure in fetching webfinger input", e.getMessage());
 			}
 

--- a/openid-connect-client/src/test/java/org/mitre/oauth2/introspectingfilter/service/impl/TestScopeBasedIntrospectionAuthoritiesGranter.java
+++ b/openid-connect-client/src/test/java/org/mitre/oauth2/introspectingfilter/service/impl/TestScopeBasedIntrospectionAuthoritiesGranter.java
@@ -54,7 +54,7 @@ public class TestScopeBasedIntrospectionAuthoritiesGranter {
 	public void testGetAuthoritiesJsonObject_withScopes() {
 		introspectionResponse.addProperty("scope", "foo bar baz batman");
 		
-		List<GrantedAuthority> expected = new ArrayList<>();
+		List<GrantedAuthority> expected = new ArrayList<GrantedAuthority>();
 		expected.add(new SimpleGrantedAuthority("ROLE_API"));
 		expected.add(new SimpleGrantedAuthority("OAUTH_SCOPE_foo"));
 		expected.add(new SimpleGrantedAuthority("OAUTH_SCOPE_bar"));
@@ -73,7 +73,7 @@ public class TestScopeBasedIntrospectionAuthoritiesGranter {
 	@Test
 	public void testGetAuthoritiesJsonObject_withoutScopes() {
 		
-		List<GrantedAuthority> expected = new ArrayList<>();
+		List<GrantedAuthority> expected = new ArrayList<GrantedAuthority>();
 		expected.add(new SimpleGrantedAuthority("ROLE_API"));
 		
 		List<GrantedAuthority> authorities = granter.getAuthorities(introspectionResponse);

--- a/openid-connect-client/src/test/java/org/mitre/openid/connect/client/service/impl/TestStaticClientConfigurationService.java
+++ b/openid-connect-client/src/test/java/org/mitre/openid/connect/client/service/impl/TestStaticClientConfigurationService.java
@@ -57,7 +57,7 @@ public class TestStaticClientConfigurationService {
 
 		service = new StaticClientConfigurationService();
 
-		Map<String, RegisteredClient> clients = new HashMap<>();
+		Map<String, RegisteredClient> clients = new HashMap<String, RegisteredClient>();
 		clients.put(issuer, mockClient);
 
 		service.setClients(clients);

--- a/openid-connect-client/src/test/java/org/mitre/openid/connect/client/service/impl/TestStaticServerConfigurationService.java
+++ b/openid-connect-client/src/test/java/org/mitre/openid/connect/client/service/impl/TestStaticServerConfigurationService.java
@@ -53,7 +53,7 @@ public class TestStaticServerConfigurationService {
 
 		service = new StaticServerConfigurationService();
 
-		Map<String, ServerConfiguration> servers = new HashMap<>();
+		Map<String, ServerConfiguration> servers = new HashMap<String, ServerConfiguration>();
 		servers.put(issuer, mockServerConfig);
 
 		service.setServers(servers);

--- a/openid-connect-common/pom.xml
+++ b/openid-connect-common/pom.xml
@@ -61,6 +61,7 @@
 		<dependency>
 			<groupId>com.nimbusds</groupId>
 			<artifactId>nimbus-jose-jwt</artifactId>
+			<classifier>jdk16</classifier>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.persistence</groupId>
@@ -97,7 +98,7 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
 					<source>${java-version}</source>
-					<target>${java-version}</target>
+					<target>${java-compile}</target>
 				</configuration>
 			</plugin>
 			<!-- BUILD SOURCE FILES -->

--- a/openid-connect-common/src/main/java/org/mitre/jwt/encryption/service/impl/DefaultJWTEncryptionAndDecryptionService.java
+++ b/openid-connect-common/src/main/java/org/mitre/jwt/encryption/service/impl/DefaultJWTEncryptionAndDecryptionService.java
@@ -63,10 +63,10 @@ public class DefaultJWTEncryptionAndDecryptionService implements JWTEncryptionAn
 	private static final Logger logger = LoggerFactory.getLogger(DefaultJWTEncryptionAndDecryptionService.class);
 
 	// map of identifier to encrypter
-	private Map<String, JWEEncrypter> encrypters = new HashMap<>();
+	private Map<String, JWEEncrypter> encrypters = new HashMap<String, JWEEncrypter>();
 
 	// map of identifier to decrypter
-	private Map<String, JWEDecrypter> decrypters = new HashMap<>();
+	private Map<String, JWEDecrypter> decrypters = new HashMap<String, JWEDecrypter>();
 
 	private String defaultEncryptionKeyId;
 
@@ -75,7 +75,7 @@ public class DefaultJWTEncryptionAndDecryptionService implements JWTEncryptionAn
 	private JWEAlgorithm defaultAlgorithm;
 
 	// map of identifier to key
-	private Map<String, JWK> keys = new HashMap<>();
+	private Map<String, JWK> keys = new HashMap<String, JWK>();
 
 	/**
 	 * Build this service based on the keys given. All public keys will be used to make encrypters,
@@ -275,7 +275,7 @@ public class DefaultJWTEncryptionAndDecryptionService implements JWTEncryptionAn
 
 	@Override
 	public Map<String, JWK> getAllPublicKeys() {
-		Map<String, JWK> pubKeys = new HashMap<>();
+		Map<String, JWK> pubKeys = new HashMap<String, JWK>();
 
 		// pull out all public keys
 		for (String keyId : keys.keySet()) {
@@ -291,7 +291,7 @@ public class DefaultJWTEncryptionAndDecryptionService implements JWTEncryptionAn
 
 	@Override
 	public Collection<JWEAlgorithm> getAllEncryptionAlgsSupported() {
-		Set<JWEAlgorithm> algs = new HashSet<>();
+		Set<JWEAlgorithm> algs = new HashSet<JWEAlgorithm>();
 
 		for (JWEEncrypter encrypter : encrypters.values()) {
 			algs.addAll(encrypter.supportedJWEAlgorithms());
@@ -309,7 +309,7 @@ public class DefaultJWTEncryptionAndDecryptionService implements JWTEncryptionAn
 	 */
 	@Override
 	public Collection<EncryptionMethod> getAllEncryptionEncsSupported() {
-		Set<EncryptionMethod> encs = new HashSet<>();
+		Set<EncryptionMethod> encs = new HashSet<EncryptionMethod>();
 
 		for (JWEEncrypter encrypter : encrypters.values()) {
 			encs.addAll(encrypter.supportedEncryptionMethods());

--- a/openid-connect-common/src/main/java/org/mitre/jwt/signer/service/impl/ClientKeyCacheService.java
+++ b/openid-connect-common/src/main/java/org/mitre/jwt/signer/service/impl/ClientKeyCacheService.java
@@ -109,7 +109,10 @@ public class ClientKeyCacheService {
 
 				return null;
 			}
-		} catch (UncheckedExecutionException | ExecutionException e) {
+		} catch (ExecutionException e) {
+			logger.error("Problem loading client validator", e);
+			return null;
+		} catch (UncheckedExecutionException e) {
 			logger.error("Problem loading client validator", e);
 			return null;
 		}
@@ -126,7 +129,10 @@ public class ClientKeyCacheService {
 			} else {
 				return null;
 			}
-		} catch (UncheckedExecutionException | ExecutionException e) {
+		} catch (ExecutionException e) {
+			logger.error("Problem loading client encrypter", e);
+			return null;
+		} catch (UncheckedExecutionException e) {
 			logger.error("Problem loading client encrypter", e);
 			return null;
 		}

--- a/openid-connect-common/src/main/java/org/mitre/jwt/signer/service/impl/DefaultJWTSigningAndValidationService.java
+++ b/openid-connect-common/src/main/java/org/mitre/jwt/signer/service/impl/DefaultJWTSigningAndValidationService.java
@@ -52,10 +52,10 @@ import com.nimbusds.jwt.SignedJWT;
 public class DefaultJWTSigningAndValidationService implements JWTSigningAndValidationService {
 
 	// map of identifier to signer
-	private Map<String, JWSSigner> signers = new HashMap<>();
+	private Map<String, JWSSigner> signers = new HashMap<String, JWSSigner>();
 
 	// map of identifier to verifier
-	private Map<String, JWSVerifier> verifiers = new HashMap<>();
+	private Map<String, JWSVerifier> verifiers = new HashMap<String, JWSVerifier>();
 
 	/**
 	 * Logger for this class
@@ -67,7 +67,7 @@ public class DefaultJWTSigningAndValidationService implements JWTSigningAndValid
 	private JWSAlgorithm defaultAlgorithm;
 
 	// map of identifier to key
-	private Map<String, JWK> keys = new HashMap<>();
+	private Map<String, JWK> keys = new HashMap<String, JWK>();
 
 	/**
 	 * Build this service based on the keys given. All public keys will be used
@@ -275,7 +275,7 @@ public class DefaultJWTSigningAndValidationService implements JWTSigningAndValid
 
 	@Override
 	public Map<String, JWK> getAllPublicKeys() {
-		Map<String, JWK> pubKeys = new HashMap<>();
+		Map<String, JWK> pubKeys = new HashMap<String, JWK>();
 
 		// pull all keys out of the verifiers if we know how
 		for (String keyId : keys.keySet()) {
@@ -295,7 +295,7 @@ public class DefaultJWTSigningAndValidationService implements JWTSigningAndValid
 	@Override
 	public Collection<JWSAlgorithm> getAllSigningAlgsSupported() {
 
-		Set<JWSAlgorithm> algs = new HashSet<>();
+		Set<JWSAlgorithm> algs = new HashSet<JWSAlgorithm>();
 
 		for (JWSSigner signer : signers.values()) {
 			algs.addAll(signer.supportedJWSAlgorithms());

--- a/openid-connect-common/src/main/java/org/mitre/jwt/signer/service/impl/JWKSetCacheService.java
+++ b/openid-connect-common/src/main/java/org/mitre/jwt/signer/service/impl/JWKSetCacheService.java
@@ -84,7 +84,10 @@ public class JWKSetCacheService {
 	public JWTSigningAndValidationService getValidator(String jwksUri) {
 		try {
 			return validators.get(jwksUri);
-		} catch (UncheckedExecutionException | ExecutionException e) {
+		} catch (ExecutionException e) {
+			logger.warn("Couldn't load JWK Set from " + jwksUri + ": " + e.getMessage());
+			return null;
+		} catch (UncheckedExecutionException e) {
 			logger.warn("Couldn't load JWK Set from " + jwksUri + ": " + e.getMessage());
 			return null;
 		}
@@ -93,7 +96,10 @@ public class JWKSetCacheService {
 	public JWTEncryptionAndDecryptionService getEncrypter(String jwksUri) {
 		try {
 			return encrypters.get(jwksUri);
-		} catch (UncheckedExecutionException | ExecutionException e) {
+		} catch (ExecutionException e) {
+			logger.warn("Couldn't load JWK Set from " + jwksUri + ": " + e.getMessage());
+			return null;
+		} catch (UncheckedExecutionException e) {
 			logger.warn("Couldn't load JWK Set from " + jwksUri + ": " + e.getMessage());
 			return null;
 		}
@@ -147,7 +153,9 @@ public class JWKSetCacheService {
 				JWTEncryptionAndDecryptionService service = new DefaultJWTEncryptionAndDecryptionService(keyStore);
 	
 				return service;
-			} catch (JsonParseException | RestClientException e) {
+			} catch (RestClientException e) {
+				throw new IllegalArgumentException("Unable to load JWK Set");
+			} catch (JsonParseException e) {
 				throw new IllegalArgumentException("Unable to load JWK Set");
 			}
 		}

--- a/openid-connect-common/src/main/java/org/mitre/jwt/signer/service/impl/SymmetricKeyJWTValidatorCacheService.java
+++ b/openid-connect-common/src/main/java/org/mitre/jwt/signer/service/impl/SymmetricKeyJWTValidatorCacheService.java
@@ -107,7 +107,9 @@ public class SymmetricKeyJWTValidatorCacheService {
 
 				return service;
 
-			} catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
+			} catch (InvalidKeySpecException e) {
+				logger.error("Couldn't create symmetric validator for client", e);
+			} catch (NoSuchAlgorithmException e) {
 				logger.error("Couldn't create symmetric validator for client", e);
 			}
 

--- a/openid-connect-common/src/main/java/org/mitre/oauth2/model/AuthenticationHolderEntity.java
+++ b/openid-connect-common/src/main/java/org/mitre/oauth2/model/AuthenticationHolderEntity.java
@@ -168,7 +168,7 @@ public class AuthenticationHolderEntity {
 	 */
 	public void setAuthorities(Collection<? extends GrantedAuthority> authorities) {
 		if (authorities != null) {
-			this.authorities = new HashSet<>(authorities);
+			this.authorities = new HashSet<GrantedAuthority>(authorities);
 		} else {
 			this.authorities = null;
 		}
@@ -192,7 +192,7 @@ public class AuthenticationHolderEntity {
 	 */
 	public void setResourceIds(Set<String> resourceIds) {
 		if (resourceIds != null) {
-			this.resourceIds = new HashSet<>(resourceIds);
+			this.resourceIds = new HashSet<String>(resourceIds);
 		} else {
 			this.resourceIds = null;
 		}
@@ -248,7 +248,7 @@ public class AuthenticationHolderEntity {
 	 */
 	public void setResponseTypes(Set<String> responseTypes) {
 		if (responseTypes != null) {
-			this.responseTypes = new HashSet<>(responseTypes);
+			this.responseTypes = new HashSet<String>(responseTypes);
 		} else {
 			this.responseTypes = null;
 		}
@@ -274,7 +274,7 @@ public class AuthenticationHolderEntity {
 	 */
 	public void setExtensions(Map<String, Serializable> extensions) {
 		if (extensions != null) {
-			this.extensions = new HashMap<>(extensions);
+			this.extensions = new HashMap<String, Serializable>(extensions);
 		} else {
 			this.extensions = null;
 		}
@@ -314,7 +314,7 @@ public class AuthenticationHolderEntity {
 	 */
 	public void setScope(Set<String> scope) {
 		if (scope != null) {
-			this.scope = new HashSet<>(scope);
+			this.scope = new HashSet<String>(scope);
 		} else {
 			this.scope = null;
 		}
@@ -339,7 +339,7 @@ public class AuthenticationHolderEntity {
 	 */
 	public void setRequestParameters(Map<String, String> requestParameters) {
 		if (requestParameters != null) {
-			this.requestParameters = new HashMap<>(requestParameters);
+			this.requestParameters = new HashMap<String, String>(requestParameters);
 		} else {
 			this.requestParameters = null;
 		}

--- a/openid-connect-common/src/main/java/org/mitre/oauth2/model/ClientDetailsEntity.java
+++ b/openid-connect-common/src/main/java/org/mitre/oauth2/model/ClientDetailsEntity.java
@@ -86,16 +86,16 @@ public class ClientDetailsEntity implements ClientDetails {
 	/** Fields from the OAuth2 Dynamic Registration Specification */
 	private String clientId = null; // client_id
 	private String clientSecret = null; // client_secret
-	private Set<String> redirectUris = new HashSet<>(); // redirect_uris
+	private Set<String> redirectUris = new HashSet<String>(); // redirect_uris
 	private String clientName; // client_name
 	private String clientUri; // client_uri
 	private String logoUri; // logo_uri
 	private Set<String> contacts; // contacts
 	private String tosUri; // tos_uri
 	private AuthMethod tokenEndpointAuthMethod = AuthMethod.SECRET_BASIC; // token_endpoint_auth_method
-	private Set<String> scope = new HashSet<>(); // scope
-	private Set<String> grantTypes = new HashSet<>(); // grant_types
-	private Set<String> responseTypes = new HashSet<>(); // response_types
+	private Set<String> scope = new HashSet<String>(); // scope
+	private Set<String> grantTypes = new HashSet<String>(); // grant_types
+	private Set<String> responseTypes = new HashSet<String>(); // response_types
 	private String policyUri;
 	private String jwksUri; // URI pointer to keys
 	private JWKSet jwks; // public key stored by value
@@ -127,11 +127,11 @@ public class ClientDetailsEntity implements ClientDetails {
 	private Set<String> requestUris; // request_uris
 
 	/** Fields to support the ClientDetails interface **/
-	private Set<GrantedAuthority> authorities = new HashSet<>();
+	private Set<GrantedAuthority> authorities = new HashSet<GrantedAuthority>();
 	private Integer accessTokenValiditySeconds = 0; // in seconds
 	private Integer refreshTokenValiditySeconds = 0; // in seconds
-	private Set<String> resourceIds = new HashSet<>();
-	private Map<String, Object> additionalInformation = new HashMap<>();
+	private Set<String> resourceIds = new HashSet<String>();
+	private Map<String, Object> additionalInformation = new HashMap<String, Object>();
 
 	/** Our own fields **/
 	private String clientDescription = ""; // human-readable description
@@ -155,7 +155,7 @@ public class ClientDetailsEntity implements ClientDetails {
 		private final String value;
 
 		// map to aid reverse lookup
-		private static final Map<String, AuthMethod> lookup = new HashMap<>();
+		private static final Map<String, AuthMethod> lookup = new HashMap<String, AuthMethod>();
 		static {
 			for (AuthMethod a : AuthMethod.values()) {
 				lookup.put(a.getValue(), a);
@@ -181,7 +181,7 @@ public class ClientDetailsEntity implements ClientDetails {
 		private final String value;
 
 		// map to aid reverse lookup
-		private static final Map<String, AppType> lookup = new HashMap<>();
+		private static final Map<String, AppType> lookup = new HashMap<String, AppType>();
 		static {
 			for (AppType a : AppType.values()) {
 				lookup.put(a.getValue(), a);
@@ -207,7 +207,7 @@ public class ClientDetailsEntity implements ClientDetails {
 		private final String value;
 
 		// map to aid reverse lookup
-		private static final Map<String, SubjectType> lookup = new HashMap<>();
+		private static final Map<String, SubjectType> lookup = new HashMap<String, SubjectType>();
 		static {
 			for (SubjectType u : SubjectType.values()) {
 				lookup.put(u.getValue(), u);

--- a/openid-connect-common/src/main/java/org/mitre/oauth2/model/OAuth2AccessTokenEntity.java
+++ b/openid-connect-common/src/main/java/org/mitre/oauth2/model/OAuth2AccessTokenEntity.java
@@ -145,7 +145,7 @@ public class OAuth2AccessTokenEntity implements OAuth2AccessToken {
 	@Override
 	@Transient
 	public Map<String, Object> getAdditionalInformation() {
-		Map<String, Object> map = new HashMap<>(); //super.getAdditionalInformation();
+		Map<String, Object> map = new HashMap<String, Object>(); //super.getAdditionalInformation();
 		if (getIdToken() != null) {
 			map.put(ID_TOKEN_FIELD_NAME, getIdTokenString());
 		}

--- a/openid-connect-common/src/main/java/org/mitre/oauth2/model/SavedUserAuthentication.java
+++ b/openid-connect-common/src/main/java/org/mitre/oauth2/model/SavedUserAuthentication.java
@@ -177,7 +177,7 @@ public class SavedUserAuthentication implements Authentication {
 	 */
 	public void setAuthorities(Collection<? extends GrantedAuthority> authorities) {
 		if (authorities != null) {
-			this.authorities = new HashSet<>(authorities);
+			this.authorities = new HashSet<GrantedAuthority>(authorities);
 		} else {
 			this.authorities = null;
 		}

--- a/openid-connect-common/src/main/java/org/mitre/oauth2/service/impl/DefaultClientUserDetailsService.java
+++ b/openid-connect-common/src/main/java/org/mitre/oauth2/service/impl/DefaultClientUserDetailsService.java
@@ -79,7 +79,7 @@ public class DefaultClientUserDetailsService implements UserDetailsService {
 				boolean accountNonExpired = true;
 				boolean credentialsNonExpired = true;
 				boolean accountNonLocked = true;
-				Collection<GrantedAuthority> authorities = new HashSet<>(client.getAuthorities());
+				Collection<GrantedAuthority> authorities = new HashSet<GrantedAuthority>(client.getAuthorities());
 				authorities.add(ROLE_CLIENT);
 
 				return new User(clientId, password, enabled, accountNonExpired, credentialsNonExpired, accountNonLocked, authorities);

--- a/openid-connect-common/src/main/java/org/mitre/oauth2/service/impl/UriEncodedClientUserDetailsService.java
+++ b/openid-connect-common/src/main/java/org/mitre/oauth2/service/impl/UriEncodedClientUserDetailsService.java
@@ -85,14 +85,16 @@ public class UriEncodedClientUserDetailsService implements UserDetailsService {
 				boolean accountNonExpired = true;
 				boolean credentialsNonExpired = true;
 				boolean accountNonLocked = true;
-				Collection<GrantedAuthority> authorities = new HashSet<>(client.getAuthorities());
+				Collection<GrantedAuthority> authorities = new HashSet<GrantedAuthority>(client.getAuthorities());
 				authorities.add(ROLE_CLIENT);
 
 				return new User(decodedClientId, encodedPassword, enabled, accountNonExpired, credentialsNonExpired, accountNonLocked, authorities);
 			} else {
 				throw new UsernameNotFoundException("Client not found: " + clientId);
 			}
-		} catch (UnsupportedEncodingException | InvalidClientException e) {
+		} catch (InvalidClientException e) {
+			throw new UsernameNotFoundException("Client not found: " + clientId);
+		} catch (UnsupportedEncodingException e) {
 			throw new UsernameNotFoundException("Client not found: " + clientId);
 		}
 

--- a/openid-connect-common/src/main/java/org/mitre/openid/connect/view/JWKSetView.java
+++ b/openid-connect-common/src/main/java/org/mitre/openid/connect/view/JWKSetView.java
@@ -58,7 +58,7 @@ public class JWKSetView extends AbstractView {
 		//BiMap<String, PublicKey> keyMap = (BiMap<String, PublicKey>) model.get("keys");
 		Map<String, JWK> keys = (Map<String, JWK>) model.get("keys");
 
-		JWKSet jwkSet = new JWKSet(new ArrayList<>(keys.values()));
+		JWKSet jwkSet = new JWKSet(new ArrayList<JWK>(keys.values()));
 
 		try {
 

--- a/openid-connect-common/src/main/java/org/mitre/uma/model/ResourceSet.java
+++ b/openid-connect-common/src/main/java/org/mitre/uma/model/ResourceSet.java
@@ -58,13 +58,13 @@ public class ResourceSet {
 	private String name;
 	private String uri;
 	private String type;
-	private Set<String> scopes = new HashSet<>();
+	private Set<String> scopes = new HashSet<String>();
 	private String iconUri;
 
 	private String owner; // username of the person responsible for the registration (either directly or via OAuth token)
 	private String clientId; // client id of the protected resource that registered this resource set via OAuth token
 
-	private Collection<Policy> policies = new HashSet<>();
+	private Collection<Policy> policies = new HashSet<Policy>();
 
 	/**
 	 * @return the id

--- a/openid-connect-common/src/main/java/org/mitre/util/JsonUtils.java
+++ b/openid-connect-common/src/main/java/org/mitre/util/JsonUtils.java
@@ -222,7 +222,7 @@ public class JsonUtils {
 	public static List<JWSAlgorithm> getAsJwsAlgorithmList(JsonObject o, String member) {
 		List<String> strings = getAsStringList(o, member);
 		if (strings != null) {
-			List<JWSAlgorithm> algs = new ArrayList<>();
+			List<JWSAlgorithm> algs = new ArrayList<JWSAlgorithm>();
 			for (String alg : strings) {
 				algs.add(JWSAlgorithm.parse(alg));
 			}
@@ -238,7 +238,7 @@ public class JsonUtils {
 	public static List<JWEAlgorithm> getAsJweAlgorithmList(JsonObject o, String member) {
 		List<String> strings = getAsStringList(o, member);
 		if (strings != null) {
-			List<JWEAlgorithm> algs = new ArrayList<>();
+			List<JWEAlgorithm> algs = new ArrayList<JWEAlgorithm>();
 			for (String alg : strings) {
 				algs.add(JWEAlgorithm.parse(alg));
 			}
@@ -254,7 +254,7 @@ public class JsonUtils {
 	public static List<EncryptionMethod> getAsEncryptionMethodList(JsonObject o, String member) {
 		List<String> strings = getAsStringList(o, member);
 		if (strings != null) {
-			List<EncryptionMethod> algs = new ArrayList<>();
+			List<EncryptionMethod> algs = new ArrayList<EncryptionMethod>();
 			for (String alg : strings) {
 				algs.add(EncryptionMethod.parse(alg));
 			}
@@ -265,7 +265,7 @@ public class JsonUtils {
 	}
 
 	public static Map readMap(JsonReader reader) throws IOException {
-		Map map = new HashMap<>();
+		Map<String, Object> map = new HashMap<String, Object>();
 		reader.beginObject();
 		while(reader.hasNext()) {
 			String name = reader.nextName();
@@ -296,13 +296,13 @@ public class JsonUtils {
 		reader.beginArray();
 		switch (reader.peek()) {
 		case STRING:
-			arraySet = new HashSet<>();
+			arraySet = new HashSet<String>();
 			while (reader.hasNext()) {
 				arraySet.add(reader.nextString());
 			}
 			break;
 		case NUMBER:
-			arraySet = new HashSet<>();
+			arraySet = new HashSet<Long>();
 			while (reader.hasNext()) {
 				arraySet.add(reader.nextLong());
 			}

--- a/openid-connect-common/src/test/java/org/mitre/jose/TestJWKSetKeyStore.java
+++ b/openid-connect-common/src/test/java/org/mitre/jose/TestJWKSetKeyStore.java
@@ -82,7 +82,7 @@ public class TestJWKSetKeyStore {
 			KeyUse.ENCRYPTION, null, JWEAlgorithm.RSA1_5, RSAkid_rsa2, null, null, null);
 
 
-	List<JWK> keys_list = new LinkedList<>();
+	List<JWK> keys_list = new LinkedList<JWK>();
 	private JWKSet jwkSet;
 	private String ks_file = "ks.txt";
 	private String ks_file_badJWK = "ks_badJWK.txt";

--- a/openid-connect-common/src/test/java/org/mitre/jwt/encryption/service/impl/TestDefaultJWTEncryptionAndDecryptionService.java
+++ b/openid-connect-common/src/test/java/org/mitre/jwt/encryption/service/impl/TestDefaultJWTEncryptionAndDecryptionService.java
@@ -147,7 +147,7 @@ public class TestDefaultJWTEncryptionAndDecryptionService {
 			.build();
 
 
-	private List<JWK> keys_list = new LinkedList<>();
+	private List<JWK> keys_list = new LinkedList<JWK>();
 
 	private DefaultJWTEncryptionAndDecryptionService service;
 	private DefaultJWTEncryptionAndDecryptionService service_2;

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,8 @@
 	</mailingLists>
 
 	<properties>
-		<java-version>1.7</java-version>
+		<java-version>1.6</java-version>
+		<java-compile>1.6</java-compile>
 		<org.slf4j-version>1.7.12</org.slf4j-version>
 	</properties>
 	<description>A reference implementation of OpenID Connect (http://openid.net/connect/), OAuth 2.0, and UMA built on top of Java, Spring, and Spring Security. The project contains a fully functioning server, client, and utility library.</description>
@@ -409,6 +410,18 @@
 				<version>1.9.5</version>
 				<scope>test</scope>
 			</dependency>
+			<dependency>
+				<groupId>org.springframework</groupId>
+				<artifactId>spring-test</artifactId>
+				<version>4.1.9.RELEASE</version>
+				<scope>test</scope>
+				<exclusions>
+					<exclusion>
+						<groupId>commons-logging</groupId>
+						<artifactId>commons-logging</artifactId>
+					</exclusion>
+				</exclusions>
+			</dependency>
 
 			<!-- MITREid Connect components -->
 			<dependency>
@@ -475,7 +488,8 @@
 			<dependency>
 				<groupId>com.nimbusds</groupId>
 				<artifactId>nimbus-jose-jwt</artifactId>
-				<version>4.3</version>
+				<classifier>jdk16</classifier>
+				<version>4.22</version>
 			</dependency>
 			<dependency>
 			    <groupId>org.bouncycastle</groupId>


### PR DESCRIPTION
Enabling jdk compilation compatibility in the client component.
Remove java 7 language feature  (diamond generic and global catch)
Upgrade JOSE to 4.22 with a jdk16 classifier
Scoping spring-test dependency to test
It would be nice if the modifications below were made in a maven profile

Scoping the following dependencies to provided in the client component:
- org.apache.httpcomponents:httpclient
- com.google.code.gson:gson
- com.nimbusds:nimbus-jose-jwt
- org.springframework.security.oauth:spring-security-oauth2
- com.google.guava:guava