### PR TITLE
Set the encoding of the UserInfo response body to UTF-8

### DIFF
--- a/openid-connect-server/src/main/java/org/mitre/openid/connect/view/UserInfoView.java
+++ b/openid-connect-server/src/main/java/org/mitre/openid/connect/view/UserInfoView.java
@@ -99,6 +99,7 @@ public class UserInfoView extends AbstractView {
 		Set<String> scope = (Set<String>) model.get(SCOPE);
 
 		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+		response.setCharacterEncoding("UTF-8");
 
 
 		JsonObject authorizedClaims = null;


### PR DESCRIPTION
This sets the encoding of the UserInfo Endpoint response body explicitly to UTF-8.

Based on the [specification](http://openid.net/specs/openid-connect-core-1_0.html#UserInfoResponse):

>   The content-type of the HTTP response MUST be application/json if the response body is a text JSON object; the response body SHOULD be encoded using UTF-8.

The PR has been tested with both Jetty and Apache Tomcat. See example response headers when invoking `curl -H "Authorization: Bearer ${access_token}" "${oidc_server}/userinfo"` before and after the change:

```
HTTP/1.1 200 OK
Date: Mon, 05 Sep 2016 23:12:35 GMT
Access-Control-Allow-Origin: *
Content-Language: en
Content-Type: application/json;charset=iso-8859-1
Content-Length: 285
Server: Jetty(9.3.5.v20151012)
```

```
HTTP/1.1 200 OK
Date: Mon, 05 Sep 2016 23:21:37 GMT
Access-Control-Allow-Origin: *
Content-Language: en
Content-Type: application/json;charset=utf-8
Content-Length: 286
Server: Jetty(9.3.5.v20151012)
```

See also related commit 8f81278
