### PR TITLE
Fixed NPE in case if algorithm is not specified

### DIFF
--- a/openid-connect-client/src/main/java/org/mitre/openid/connect/client/OIDCAuthenticationFilter.java
+++ b/openid-connect-client/src/main/java/org/mitre/openid/connect/client/OIDCAuthenticationFilter.java
@@ -381,9 +381,9 @@ public class OIDCAuthenticationFilter extends AbstractAuthenticationProcessingFi
 				JWSAlgorithm alg = clientConfig.getTokenEndpointAuthSigningAlg();
 
 				if (SECRET_JWT.equals(clientConfig.getTokenEndpointAuthMethod()) &&
-						(alg.equals(JWSAlgorithm.HS256)
-								|| alg.equals(JWSAlgorithm.HS384)
-								|| alg.equals(JWSAlgorithm.HS512))) {
+						(JWSAlgorithm.HS256.equals(alg)
+								|| JWSAlgorithm.HS384.equals(alg)
+								|| JWSAlgorithm.HS512.equals(alg))) {
 
 					// generate one based on client secret
 					signer = symmetricCacheService.getSymmetricValidtor(clientConfig.getClient());


### PR DESCRIPTION
In case if token endpoint auth method is set to client_secret_jwt and signing algorithm is not specified the system fails with NPE in  `org.mitre.openid.connect.client.OIDCAuthenticationFilter#handleAuthorizationCodeResponse`

There is a predefined validation that should work in this case. The validation checks signer service and throws AuthenticationServiceException with human readable message "Couldn't find required signer service for use with private key auth". 
The issue is that the system fails with NPE before entering into the validation code.
