### PR TITLE
Fix DefaultIntrospectionResultAssembler and IntrospectingTokenService to populate and parse `user_id` according to user authentication

### DIFF
--- a/openid-connect-client/src/main/java/org/mitre/oauth2/introspectingfilter/IntrospectingTokenService.java
+++ b/openid-connect-client/src/main/java/org/mitre/oauth2/introspectingfilter/IntrospectingTokenService.java
@@ -235,8 +235,13 @@ public class IntrospectingTokenService implements ResourceServerTokenServices {
 		return storedRequest;
 	}
 
-	private Authentication createAuthentication(JsonObject token) {
-		return new PreAuthenticatedAuthenticationToken(token.get("sub").getAsString(), token, introspectionAuthorityGranter.getAuthorities(token));
+	private Authentication createUserAuthentication(JsonObject token) {
+		JsonElement userId = token.get("user_id");
+		if(userId == null) {
+			return null;
+		}
+
+		return new PreAuthenticatedAuthenticationToken(userId.getAsString(), token, introspectionAuthorityGranter.getAuthorities(token));
 	}
 
 	private OAuth2AccessToken createAccessToken(final JsonObject token, final String tokenString) {
@@ -321,7 +326,7 @@ public class IntrospectingTokenService implements ResourceServerTokenServices {
 				return null;
 			}
 			// create an OAuth2Authentication
-			OAuth2Authentication auth = new OAuth2Authentication(createStoredRequest(tokenResponse), createAuthentication(tokenResponse));
+			OAuth2Authentication auth = new OAuth2Authentication(createStoredRequest(tokenResponse), createUserAuthentication(tokenResponse));
 			// create an OAuth2AccessToken
 			OAuth2AccessToken token = createAccessToken(tokenResponse, accessToken);
 

--- a/openid-connect-server/src/main/java/org/mitre/oauth2/service/impl/DefaultIntrospectionResultAssembler.java
+++ b/openid-connect-server/src/main/java/org/mitre/oauth2/service/impl/DefaultIntrospectionResultAssembler.java
@@ -92,7 +92,9 @@ public class DefaultIntrospectionResultAssembler implements IntrospectionResultA
 			result.put(SUB, authentication.getName());
 		}
 
-		result.put(USER_ID, authentication.getName());
+		if(authentication.getUserAuthentication() != null) {
+			result.put(USER_ID, authentication.getUserAuthentication().getName());
+		}
 
 		result.put(CLIENT_ID, authentication.getOAuth2Request().getClientId());
 
@@ -131,7 +133,9 @@ public class DefaultIntrospectionResultAssembler implements IntrospectionResultA
 			result.put(SUB, authentication.getName());
 		}
 
-		result.put(USER_ID, authentication.getName());
+		if(authentication.getUserAuthentication() != null) {
+			result.put(USER_ID, authentication.getUserAuthentication().getName());
+		}
 
 		result.put(CLIENT_ID, authentication.getOAuth2Request().getClientId());
 

--- a/openid-connect-server/src/test/java/org/mitre/oauth2/service/impl/TestDefaultIntrospectionResultAssembler.java
+++ b/openid-connect-server/src/test/java/org/mitre/oauth2/service/impl/TestDefaultIntrospectionResultAssembler.java
@@ -179,6 +179,31 @@ public class TestDefaultIntrospectionResultAssembler {
 	}
 
 	@Test
+    public void shouldAssembleExpectedResultForAccessTokenWithoutUserAuthentication() throws ParseException {
+        // given
+        OAuth2AccessTokenEntity accessToken = accessToken(new Date(123 * 1000L), scopes("foo", "bar"), null, "Bearer",
+                oauth2Authentication(oauth2Request("clientId"), null));
+
+        Set<String> authScopes = scopes("foo", "bar", "baz");
+
+        // when
+        Map<String, Object> result = assembler.assembleFrom(accessToken, null, authScopes);
+
+
+        // then `user_id` should not be present
+        Map<String, Object> expected = new ImmutableMap.Builder<String, Object>()
+                .put("sub", "clientId")
+                .put("exp", 123L)
+                .put("expires_at", dateFormat.valueToString(new Date(123 * 1000L)))
+                .put("scope", "bar foo")
+                .put("active", Boolean.TRUE)
+                .put("client_id", "clientId")
+                .put("token_type", "Bearer")
+                .build();
+        assertThat(result, is(equalTo(expected)));
+    }
+
+	@Test
 	public void shouldAssembleExpectedResultForRefreshToken() throws ParseException {
 
 		// given
@@ -257,6 +282,30 @@ public class TestDefaultIntrospectionResultAssembler {
 				.build();
 		assertThat(result, is(equalTo(expected)));
 	}
+
+    @Test
+    public void shouldAssembleExpectedResultForRefreshTokenWithoutUserAuthentication() throws ParseException {
+        // given
+        OAuth2RefreshTokenEntity refreshToken = refreshToken(null,
+                oauth2Authentication(oauth2Request("clientId", scopes("foo",  "bar")), null));
+
+        Set<String> authScopes = scopes("foo", "bar", "baz");
+
+        // when
+        Map<String, Object> result = assembler.assembleFrom(refreshToken, null, authScopes);
+
+
+        // then `user_id` should not be present
+        Map<String, Object> expected = new ImmutableMap.Builder<String, Object>()
+                .put("sub", "clientId")
+                .put("scope", "bar foo")
+                .put("active", Boolean.TRUE)
+                .put("client_id", "clientId")
+                .build();
+        assertThat(result, is(equalTo(expected)));
+    }
+
+
 
 	private UserInfo userInfo(String sub) {
 		UserInfo userInfo = mock(UserInfo.class);

--- a/openid-connect-server/src/test/java/org/mitre/oauth2/service/impl/TestDefaultIntrospectionResultAssembler.java
+++ b/openid-connect-server/src/test/java/org/mitre/oauth2/service/impl/TestDefaultIntrospectionResultAssembler.java
@@ -30,6 +30,8 @@ import org.mitre.oauth2.model.OAuth2RefreshTokenEntity;
 import org.mitre.oauth2.service.IntrospectionResultAssembler;
 import org.mitre.openid.connect.model.UserInfo;
 import org.mitre.uma.model.Permission;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.provider.OAuth2Authentication;
 import org.springframework.security.oauth2.provider.OAuth2Request;
 
@@ -59,7 +61,7 @@ public class TestDefaultIntrospectionResultAssembler {
 
 		// given
 		OAuth2AccessTokenEntity accessToken = accessToken(new Date(123 * 1000L), scopes("foo", "bar"), null, "Bearer",
-				authentication("name", request("clientId")));
+                oauth2AuthenticationWithUser(oauth2Request("clientId"), "name"));
 
 		UserInfo userInfo = userInfo("sub");
 
@@ -89,7 +91,7 @@ public class TestDefaultIntrospectionResultAssembler {
 		// given
 		OAuth2AccessTokenEntity accessToken = accessToken(new Date(123 * 1000L), scopes("foo", "bar"),
 				permissions(permission(1L, "foo", "bar")),
-				"Bearer", authentication("name", request("clientId")));
+                "Bearer", oauth2AuthenticationWithUser(oauth2Request("clientId"), "name"));
 
 		UserInfo userInfo = userInfo("sub");
 
@@ -127,7 +129,7 @@ public class TestDefaultIntrospectionResultAssembler {
 
 		// given
 		OAuth2AccessTokenEntity accessToken = accessToken(new Date(123 * 1000L), scopes("foo", "bar"), null, "Bearer",
-				authentication("name", request("clientId")));
+				oauth2AuthenticationWithUser(oauth2Request("clientId"), "name"));
 
 		Set<String> authScopes = scopes("foo", "bar", "baz");
 
@@ -154,7 +156,7 @@ public class TestDefaultIntrospectionResultAssembler {
 
 		// given
 		OAuth2AccessTokenEntity accessToken = accessToken(null, scopes("foo", "bar"), null, "Bearer",
-				authentication("name", request("clientId")));
+                oauth2AuthenticationWithUser(oauth2Request("clientId"), "name"));
 
 		UserInfo userInfo = userInfo("sub");
 
@@ -181,7 +183,7 @@ public class TestDefaultIntrospectionResultAssembler {
 
 		// given
 		OAuth2RefreshTokenEntity refreshToken = refreshToken(new Date(123 * 1000L),
-				authentication("name", request("clientId", scopes("foo",  "bar"))));
+                oauth2AuthenticationWithUser(oauth2Request("clientId", scopes("foo", "bar")), "name"));
 
 		UserInfo userInfo = userInfo("sub");
 
@@ -209,7 +211,7 @@ public class TestDefaultIntrospectionResultAssembler {
 
 		// given
 		OAuth2RefreshTokenEntity refreshToken = refreshToken(new Date(123 * 1000L),
-				authentication("name", request("clientId", scopes("foo",  "bar"))));
+				oauth2AuthenticationWithUser(oauth2Request("clientId", scopes("foo",  "bar")), "name"));
 
 		Set<String> authScopes = scopes("foo", "bar", "baz");
 
@@ -235,7 +237,7 @@ public class TestDefaultIntrospectionResultAssembler {
 
 		// given
 		OAuth2RefreshTokenEntity refreshToken = refreshToken(null,
-				authentication("name", request("clientId", scopes("foo",  "bar"))));
+				oauth2AuthenticationWithUser(oauth2Request("clientId", scopes("foo",  "bar")), "name"));
 
 		UserInfo userInfo = userInfo("sub");
 
@@ -279,18 +281,20 @@ public class TestDefaultIntrospectionResultAssembler {
 		return refreshToken;
 	}
 
-	private OAuth2Authentication authentication(String name, OAuth2Request request) {
-		OAuth2Authentication authentication = mock(OAuth2Authentication.class);
-		given(authentication.getName()).willReturn(name);
-		given(authentication.getOAuth2Request()).willReturn(request);
-		return authentication;
+	private OAuth2Authentication oauth2AuthenticationWithUser(OAuth2Request request, String username) {
+		UsernamePasswordAuthenticationToken userAuthentication = new UsernamePasswordAuthenticationToken(username, "somepassword");
+        return oauth2Authentication(request, userAuthentication);
 	}
 
-	private OAuth2Request request(String clientId) {
-		return request(clientId, null);
+    private OAuth2Authentication oauth2Authentication(OAuth2Request request, Authentication userAuthentication) {
+        return new OAuth2Authentication(request, userAuthentication);
+    }
+
+	private OAuth2Request oauth2Request(String clientId) {
+		return oauth2Request(clientId, null);
 	}
 
-	private OAuth2Request request(String clientId, Set<String> scopes) {
+	private OAuth2Request oauth2Request(String clientId, Set<String> scopes) {
 		return new OAuth2Request(null, clientId, null, true, scopes, null, null, null, null);
 	}
 


### PR DESCRIPTION
The problem is in both `DefaultIntrospectionResultAssembler` and `IntrospectingTokenService`

With `DefaultIntrospectionResultAssembler`, it populates `user_id` with OAuth2Authentication#getName() which in turn uses OAuth2Authentication#getPrincipal() that defaults to the client id if user authentication is not available. This leads to the `user_id` being falsely populated with the client_id when user authentication is not available. 

With `IntrospectingTokenService`, it uses `sub` which cannot be used to create the user authentication because it may not necessarily refer to the user. Instead if may refer to the client
if the access token happens to be client-only.

This merge request addresses these problems.
