### PR TITLE
Change Base64URL encoding for pkce checking

### DIFF
--- a/openid-connect-server/src/main/java/org/mitre/oauth2/service/impl/DefaultOAuth2ProviderTokenService.java
+++ b/openid-connect-server/src/main/java/org/mitre/oauth2/service/impl/DefaultOAuth2ProviderTokenService.java
@@ -26,6 +26,7 @@ import static org.mitre.openid.connect.request.ConnectRequestParameters.CODE_VER
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashSet;
@@ -204,8 +205,12 @@ public class DefaultOAuth2ProviderTokenService implements OAuth2TokenEntityServi
 				} else if (alg.equals(PKCEAlgorithm.S256)) {
 					// hash the verifier
 					try {
+						
 						MessageDigest digest = MessageDigest.getInstance("SHA-256");
-						String hash = Base64URL.encode(digest.digest(verifier.getBytes(StandardCharsets.US_ASCII))).toString();
+						digest.update(verifier.getBytes(StandardCharsets.US_ASCII));
+						byte[] bytes = digest.digest();
+						String hash = Base64.getUrlEncoder().encodeToString(bytes);
+						
 						if (!challenge.equals(hash)) {
 							throw new InvalidRequestException("Code challenge and verifier do not match");
 						}


### PR DESCRIPTION
Use Java 1.8 Base64.getUrlEncoder() to encode instead of com.nimbusds.jose.util.Base64URL.
As com.nimbusds.jose.util.Base64URL will remove the "=" at the end while Base64URL encoding only needed to remove trailling "="