### PR TITLE
Add parameters from error response to exception

### DIFF
--- a/openid-connect-client/src/main/java/org/mitre/openid/connect/client/AuthorizationEndpointException.java
+++ b/openid-connect-client/src/main/java/org/mitre/openid/connect/client/AuthorizationEndpointException.java
@@ -1,0 +1,33 @@
+package org.mitre.openid.connect.client;
+
+import org.springframework.security.authentication.AuthenticationServiceException;
+
+public class AuthorizationEndpointException extends AuthenticationServiceException {
+
+	private static final long serialVersionUID = 6953119789654778380L;
+
+	private String error;
+	
+	private String errorDescription;
+	
+	private String errorURI;
+
+	public AuthorizationEndpointException(String error, String errorDescription, String errorURI) {
+		super("Error from Authorization Endpoint: " + error + " " + errorDescription + " " + errorURI);
+		this.error = error;
+		this.errorDescription = errorDescription;
+		this.errorURI = errorURI;
+	}
+
+	public String getError() {
+		return error;
+	}
+
+	public String getErrorDescription() {
+		return errorDescription;
+	}
+
+	public String getErrorURI() {
+		return errorURI;
+	}
+}

--- a/openid-connect-client/src/main/java/org/mitre/openid/connect/client/OIDCAuthenticationFilter.java
+++ b/openid-connect-client/src/main/java/org/mitre/openid/connect/client/OIDCAuthenticationFilter.java
@@ -649,7 +649,7 @@ public class OIDCAuthenticationFilter extends AbstractAuthenticationProcessingFi
 		String errorDescription = request.getParameter("error_description");
 		String errorURI = request.getParameter("error_uri");
 
-		throw new AuthenticationServiceException("Error from Authorization Endpoint: " + error + " " + errorDescription + " " + errorURI);
+		throw new AuthorizationEndpointException(error, errorDescription, errorURI);
 	}
 
 	/**

--- a/openid-connect-client/src/test/java/org/mitre/openid/connect/client/TestOIDCAuthenticationFilter.java
+++ b/openid-connect-client/src/test/java/org/mitre/openid/connect/client/TestOIDCAuthenticationFilter.java
@@ -1,0 +1,44 @@
+package org.mitre.openid.connect.client;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.springframework.security.authentication.AuthenticationServiceException;
+
+public class TestOIDCAuthenticationFilter {
+
+	private OIDCAuthenticationFilter filter = new OIDCAuthenticationFilter();
+	
+	@Test
+	public void attemptAuthentication_error() throws Exception {
+		
+		HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+		Mockito.when(request.getParameter("error")).thenReturn("Error");
+		Mockito.when(request.getParameter("error_description")).thenReturn("Description");
+		Mockito.when(request.getParameter("error_uri")).thenReturn("http://example.com");
+
+		try {
+			filter.attemptAuthentication(request, mock(HttpServletResponse.class));
+			
+			fail("AuthorizationEndpointException expected.");
+		}
+		catch (AuthorizationEndpointException exception) {
+			assertThat(exception.getMessage(),
+					is("Error from Authorization Endpoint: Error Description http://example.com"));
+			
+			assertThat(exception.getError(), is("Error"));
+			assertThat(exception.getErrorDescription(), is("Description"));
+			assertThat(exception.getErrorURI(), is("http://example.com"));
+
+			assertThat(exception, is(instanceOf(AuthenticationServiceException.class)));
+		}
+	}
+}


### PR DESCRIPTION
It would be useful to throw a richer exception due to an authentication error response in the client, encapsulating the parameters from the response, rather than just throwing an `AuthenticationServiceException` with a concatenated string of the parameters as its message.

This prevents having to re-retrieve the parameters in the `AuthenticationFailureHandler`, or allows you to use a redirect in a `SimpleUrlAuthenticationFailureHandler` and still display the error response parameters in the final page by retrieving the `org.springframework.security.web.WebAttributes.AUTHENTICATION_EXCEPTION` session attribute. 

The default behaviour of `SimpleUrlAuthenticationFailureHandler` is to do a redirect, which means the query parameters would have been lost. This failure handler can be configured to use a forward instead via `setUseForward()` but a redirect may be preferable for various reasons.