### PR TITLE
DefaultUserInfoService: Optimize access path

### DIFF
--- a/openid-connect-server/src/main/java/org/mitre/openid/connect/service/impl/DefaultUserInfoService.java
+++ b/openid-connect-server/src/main/java/org/mitre/openid/connect/service/impl/DefaultUserInfoService.java
@@ -52,11 +52,13 @@ public class DefaultUserInfoService implements UserInfoService {
 	@Override
 	public UserInfo getByUsernameAndClientId(String username, String clientId) {
 
-		ClientDetailsEntity client = clientService.loadClientByClientId(clientId);
-
 		UserInfo userInfo = getByUsername(username);
+		if (userInfo == null) {
+			return null;
+		}
 
-		if (client == null || userInfo == null) {
+		ClientDetailsEntity client = clientService.loadClientByClientId(clientId);
+		if (client == null) {
 			return null;
 		}
 


### PR DESCRIPTION
When no user_info is availble skip, the db access for the client
details.