### PR TITLE
UserInfoInterceptor: Exclude interceptor for /introspect endpoint

### DIFF
--- a/openid-connect-server-webapp/src/main/webapp/WEB-INF/application-context.xml
+++ b/openid-connect-server-webapp/src/main/webapp/WEB-INF/application-context.xml
@@ -45,7 +45,12 @@
 
 	<mvc:interceptors>
 		<!-- Inject the UserInfo into the response -->
-		<bean id="userInfoInterceptor" class="org.mitre.openid.connect.web.UserInfoInterceptor" />
+		<mvc:interceptor>
+			<mvc:mapping path="/**"/>
+			<!-- introspection endpoint don't need this info, exclude it -->
+			<mvc:exclude-mapping path="/#{T(org.mitre.oauth2.web.IntrospectionEndpoint).URL}**"/>
+			<bean id="userInfoInterceptor" class="org.mitre.openid.connect.web.UserInfoInterceptor" />
+		</mvc:interceptor>
 		<!-- Inject the server configuration into the response -->
 		<bean id="serverConfigInterceptor" class="org.mitre.openid.connect.web.ServerConfigInterceptor" />
 	</mvc:interceptors>


### PR DESCRIPTION
The user_info is never used in the introspection endpoint. Avoid a
roundtrip to the database here.