### PR TITLE
Statically weave some entity classes

### DIFF
--- a/openid-connect-client/pom.xml
+++ b/openid-connect-client/pom.xml
@@ -32,6 +32,11 @@
 			<groupId>org.mitre</groupId>
 			<artifactId>openid-connect-common</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.eclipse.persistence</groupId>
+			<artifactId>org.eclipse.persistence.jpa</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	<packaging>jar</packaging>
 	<build>

--- a/openid-connect-common/pom.xml
+++ b/openid-connect-common/pom.xml
@@ -86,6 +86,11 @@
 			<groupId>org.bouncycastle</groupId>
 			<artifactId>bcprov-jdk15on</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.eclipse.persistence</groupId>
+			<artifactId>org.eclipse.persistence.jpa</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<packaging>jar</packaging>
@@ -99,6 +104,29 @@
 					<source>${java-version}</source>
 					<target>${java-version}</target>
 				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>de.empulse.eclipselink</groupId>
+				<artifactId>staticweave-maven-plugin</artifactId>
+				<version>1.0.0</version>
+				<executions>
+					<execution>
+						<phase>process-classes</phase>
+						<goals>
+							<goal>weave</goal>
+						</goals>
+						<configuration>
+							<logLevel>FINE</logLevel>
+						</configuration>
+					</execution>
+				</executions>
+				<dependencies>
+					<dependency>
+						<groupId>org.eclipse.persistence</groupId>
+						<artifactId>org.eclipse.persistence.jpa</artifactId>
+						<version>${eclipselink.version}</version>
+					</dependency>
+				</dependencies>
 			</plugin>
 			<!-- BUILD SOURCE FILES -->
 			<plugin>

--- a/openid-connect-common/src/main/java/org/mitre/oauth2/model/ClientDetailsEntity.java
+++ b/openid-connect-common/src/main/java/org/mitre/oauth2/model/ClientDetailsEntity.java
@@ -57,7 +57,6 @@ import org.mitre.oauth2.model.convert.SimpleGrantedAuthorityStringConverter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.oauth2.provider.ClientDetails;
 
-import com.nimbusds.jose.Algorithm;
 import com.nimbusds.jose.EncryptionMethod;
 import com.nimbusds.jose.JWEAlgorithm;
 import com.nimbusds.jose.JWSAlgorithm;
@@ -426,7 +425,7 @@ public class ClientDetailsEntity implements ClientDetails {
 	/**
 	 * @return the scope
 	 */
-	@ElementCollection(fetch = FetchType.EAGER)
+	@ElementCollection
 	@CollectionTable(
 			name="client_scope",
 			joinColumns=@JoinColumn(name="owner_id")
@@ -447,7 +446,7 @@ public class ClientDetailsEntity implements ClientDetails {
 	/**
 	 * @return the authorizedGrantTypes
 	 */
-	@ElementCollection(fetch = FetchType.EAGER)
+	@ElementCollection
 	@CollectionTable(
 			name="client_grant_type",
 			joinColumns=@JoinColumn(name="owner_id")
@@ -476,7 +475,7 @@ public class ClientDetailsEntity implements ClientDetails {
 	/**
 	 * @return the authorities
 	 */
-	@ElementCollection(fetch = FetchType.EAGER)
+	@ElementCollection
 	@CollectionTable(
 			name="client_authority",
 			joinColumns=@JoinColumn(name="owner_id")
@@ -526,7 +525,7 @@ public class ClientDetailsEntity implements ClientDetails {
 	/**
 	 * @return the registeredRedirectUri
 	 */
-	@ElementCollection(fetch = FetchType.EAGER)
+	@ElementCollection
 	@CollectionTable(
 			name="client_redirect_uri",
 			joinColumns=@JoinColumn(name="owner_id")
@@ -556,7 +555,7 @@ public class ClientDetailsEntity implements ClientDetails {
 	 * @return the resourceIds
 	 */
 	@Override
-	@ElementCollection(fetch = FetchType.EAGER)
+	@ElementCollection
 	@CollectionTable(
 			name="client_resource",
 			joinColumns=@JoinColumn(name="owner_id")
@@ -631,7 +630,7 @@ public class ClientDetailsEntity implements ClientDetails {
 		this.subjectType = subjectType;
 	}
 
-	@ElementCollection(fetch = FetchType.EAGER)
+	@ElementCollection
 	@CollectionTable(
 			name="client_contact",
 			joinColumns=@JoinColumn(name="owner_id")
@@ -845,7 +844,7 @@ public class ClientDetailsEntity implements ClientDetails {
 	/**
 	 * @return the responseTypes
 	 */
-	@ElementCollection(fetch = FetchType.EAGER)
+	@ElementCollection
 	@CollectionTable(
 			name="client_response_type",
 			joinColumns=@JoinColumn(name="owner_id")
@@ -865,7 +864,7 @@ public class ClientDetailsEntity implements ClientDetails {
 	/**
 	 * @return the defaultACRvalues
 	 */
-	@ElementCollection(fetch = FetchType.EAGER)
+	@ElementCollection
 	@CollectionTable(
 			name="client_default_acr_value",
 			joinColumns=@JoinColumn(name="owner_id")
@@ -901,7 +900,7 @@ public class ClientDetailsEntity implements ClientDetails {
 	/**
 	 * @return the postLogoutRedirectUri
 	 */
-	@ElementCollection(fetch = FetchType.EAGER)
+	@ElementCollection
 	@CollectionTable(
 			name="client_post_logout_redirect_uri",
 			joinColumns=@JoinColumn(name="owner_id")
@@ -921,7 +920,7 @@ public class ClientDetailsEntity implements ClientDetails {
 	/**
 	 * @return the requestUris
 	 */
-	@ElementCollection(fetch = FetchType.EAGER)
+	@ElementCollection
 	@CollectionTable(
 			name="client_request_uri",
 			joinColumns=@JoinColumn(name="owner_id")
@@ -981,7 +980,7 @@ public class ClientDetailsEntity implements ClientDetails {
 	/**
 	 * @return the claimsRedirectUris
 	 */
-	@ElementCollection(fetch = FetchType.EAGER)
+	@ElementCollection
 	@CollectionTable(
 			name="client_claims_redirect_uri",
 			joinColumns=@JoinColumn(name="owner_id")

--- a/openid-connect-common/src/main/java/org/mitre/oauth2/model/OAuth2AccessTokenEntity.java
+++ b/openid-connect-common/src/main/java/org/mitre/oauth2/model/OAuth2AccessTokenEntity.java
@@ -237,7 +237,7 @@ public class OAuth2AccessTokenEntity implements OAuth2AccessToken {
 	}
 
 	@Override
-	@ElementCollection(fetch=FetchType.EAGER)
+	@ElementCollection
 	@CollectionTable(
 			joinColumns=@JoinColumn(name="owner_id"),
 			name="token_scope"

--- a/openid-connect-common/src/main/resources/META-INF/persistence.xml
+++ b/openid-connect-common/src/main/resources/META-INF/persistence.xml
@@ -1,0 +1,28 @@
+<persistence xmlns="http://xmlns.jcp.org/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence
+             http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd"
+             version="2.1">
+	<persistence-unit name="static-weaver">
+		<class>org.mitre.oauth2.model.convert.JWKSetStringConverter</class>
+		<class>org.mitre.oauth2.model.convert.JWSAlgorithmStringConverter</class>
+		<class>org.mitre.oauth2.model.convert.JWEAlgorithmStringConverter</class>
+		<class>org.mitre.oauth2.model.convert.JWTStringConverter</class>
+		<class>org.mitre.oauth2.model.convert.JWEEncryptionMethodStringConverter</class>
+		<class>org.mitre.oauth2.model.convert.PKCEAlgorithmStringConverter</class>
+		<class>org.mitre.oauth2.model.convert.SimpleGrantedAuthorityStringConverter</class>
+		<class>org.mitre.oauth2.model.ClientDetailsEntity</class>
+
+		<class>org.mitre.oauth2.model.convert.SerializableStringConverter</class>
+		<class>org.mitre.oauth2.model.convert.JsonElementStringConverter</class>
+		<class>org.mitre.oauth2.model.OAuth2AccessTokenEntity</class>
+		<class>org.mitre.oauth2.model.AuthenticationHolderEntity</class>
+		<class>org.mitre.oauth2.model.SavedUserAuthentication</class>
+		<class>org.mitre.oauth2.model.OAuth2RefreshTokenEntity</class>
+		<class>org.mitre.openid.connect.model.ApprovedSite</class>
+		<class>org.mitre.uma.model.Permission</class>
+		<class>org.mitre.uma.model.ResourceSet</class>
+		<class>org.mitre.uma.model.Policy</class>
+		<class>org.mitre.uma.model.Claim</class>
+	</persistence-unit>
+</persistence>

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@
 	<properties>
 		<java-version>1.8</java-version>
 		<org.slf4j-version>1.7.21</org.slf4j-version>
+		<eclipselink.version>2.5.1</eclipselink.version>
 	</properties>
 	<description>A reference implementation of OpenID Connect (http://openid.net/connect/), OAuth 2.0, and UMA built on top of Java, Spring, and Spring Security. The project contains a fully functioning server, client, and utility library.</description>
 	<url>https://github.com/mitreid-connect</url>
@@ -301,8 +302,7 @@
 <!--                 <artifactId>asm-attrs</artifactId> -->
 <!--             </exclusion> -->
 <!--         </exclusions> -->
- 
-        						</plugin>
+						</plugin>
 					</reportPlugins>
 				</configuration>
 			</plugin>
@@ -397,7 +397,7 @@
 			<dependency>
 				<groupId>org.eclipse.persistence</groupId>
 				<artifactId>org.eclipse.persistence.jpa</artifactId>
-				<version>2.5.1</version>
+				<version>${eclipselink.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.eclipse.persistence</groupId>


### PR DESCRIPTION
This dramatically reduces the number of SQLs that are issued by the JPA
framework for the DefaultIntrospectionAssembler case in the
IntrospectionEndpoint.