### PR TITLE
Decrease log level of trailing slash warning

### DIFF
--- a/openid-connect-server/src/main/java/org/mitre/discovery/web/DiscoveryEndpoint.java
+++ b/openid-connect-server/src/main/java/org/mitre/discovery/web/DiscoveryEndpoint.java
@@ -287,7 +287,7 @@ public class DiscoveryEndpoint {
 		String baseUrl = config.getIssuer();
 
 		if (!baseUrl.endsWith("/")) {
-			logger.warn("Configured issuer doesn't end in /, adding for discovery: " + baseUrl);
+			logger.debug("Configured issuer doesn't end in /, adding for discovery: {}", baseUrl);
 			baseUrl = baseUrl.concat("/");
 		}
 


### PR DESCRIPTION
Having an issuer without trailing slash configured is just fine, so
there is no reason to log a warning for this every time the discovery
endpoint is called.