### PR TITLE
Adjustment to generate longer codes

### DIFF
--- a/openid-connect-server/src/main/java/org/mitre/oauth2/service/impl/DefaultOAuth2AuthorizationCodeService.java
+++ b/openid-connect-server/src/main/java/org/mitre/oauth2/service/impl/DefaultOAuth2AuthorizationCodeService.java
@@ -57,7 +57,7 @@ public class DefaultOAuth2AuthorizationCodeService implements AuthorizationCodeS
 
 	private int authCodeExpirationSeconds = 60 * 5; // expire in 5 minutes by default
 
-	private RandomValueStringGenerator generator = new RandomValueStringGenerator();
+	private RandomValueStringGenerator generator = new RandomValueStringGenerator(22);
 
 	/**
 	 * Generate a random authorization code and create an AuthorizationCodeEntity,


### PR DESCRIPTION
RandomValueStringGenerator default constructor creates a code of length six only. The RFC 6819 (OAuth 2.0 Threat Model and Security Considerations) suggests (5.1.4.2.2.  Use High Entropy for Secrets) that secrets that aren't used by humans (e.g. client secrets or token handles) have a reasonable level of enthropy. They propose a token lengths of at least 128 bits. Since the RandomValueStringGenerator only uses case sensitive alpha numeric symbols, 22 symbols are needed to achieve an enthropy >=128 bits.