### PR TITLE
Use spring profile. Move configuration to new files

### DIFF
--- a/openid-connect-server-webapp/src/main/resources/openid.properties
+++ b/openid-connect-server-webapp/src/main/resources/openid.properties
@@ -1,0 +1,8 @@
+# OpenID server configuration
+openid.issuer=http://10.22.39.103:8081/ldap-openid-connect-server-webapp/
+
+# Database configuration
+jdbc.url=jdbc:hsqldb:mem:oic;sql.syntax_mys=true
+#jdbc.url=jdbc:hsqldb:file:/tmp/oic;sql.syntax_mys=true
+jdbc.username=oic
+jdbc.password=oic

--- a/openid-connect-server-webapp/src/main/resources/openid.properties
+++ b/openid-connect-server-webapp/src/main/resources/openid.properties
@@ -1,5 +1,5 @@
 # OpenID server configuration
-openid.issuer=http://10.22.39.103:8081/ldap-openid-connect-server-webapp/
+openid.issuer=http://localhost:8080/openid-connect-server-webapp/
 
 # Database configuration
 jdbc.url=jdbc:hsqldb:mem:oic;sql.syntax_mys=true

--- a/openid-connect-server-webapp/src/main/webapp/WEB-INF/application-context.xml
+++ b/openid-connect-server-webapp/src/main/webapp/WEB-INF/application-context.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2017 The MIT Internet Trust Consortium
-   
+
     Portions copyright 2011-2013 The MITRE Corporation
-   
+
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
-   
+
       http://www.apache.org/licenses/LICENSE-2.0
-   
+
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -31,6 +31,14 @@
 		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.3.xsd
 		http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.3.xsd
 		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.3.xsd">
+
+	<bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
+			<property name="locations">
+        <list>					
+					<value>classpath:openid.properties</value>
+				</list>
+	   	</property>
+	</bean>
 
 	<!-- Scan for components -->
 	<context:component-scan annotation-config="true" base-package="org.mitre" />
@@ -59,7 +67,7 @@
 			<mvc:exclude-mapping path="/#{T(org.mitre.oauth2.web.DeviceEndpoint).URL}/**" />
 			<mvc:exclude-mapping path="/#{T(org.mitre.oauth2.web.IntrospectionEndpoint).URL}**" />
 			<mvc:exclude-mapping path="/#{T(org.mitre.oauth2.web.RevocationEndpoint).URL}**" />
-					 
+
 			<!-- Inject the UserInfo into the response -->
 			<bean id="userInfoInterceptor" class="org.mitre.openid.connect.web.UserInfoInterceptor" />
 		</mvc:interceptor>
@@ -104,12 +112,12 @@
 
 	<oauth:resource-server id="resourceServerFilter" token-services-ref="defaultOAuth2ProviderTokenService" stateless="false" />
 
-	<security:http pattern="/token" 
+	<security:http pattern="/token"
 		create-session="stateless"
 		authentication-manager-ref="clientAuthenticationManager"
 		entry-point-ref="oauthAuthenticationEntryPoint"
 		use-expressions="true">
-		
+
 		<security:intercept-url pattern="/token" access="permitAll" method="OPTIONS" /> <!-- allow OPTIONS calls without auth for CORS stuff -->
 		<security:intercept-url pattern="/token" access="isAuthenticated()" />
 		<security:http-basic entry-point-ref="oauthAuthenticationEntryPoint" />
@@ -133,13 +141,13 @@
 		<security:csrf disabled="true"/>
 	</security:http>
 
-	<!-- Allow open access to all static resources -->	
+	<!-- Allow open access to all static resources -->
 	<security:http pattern="/resources/**" use-expressions="true" entry-point-ref="http403EntryPoint" create-session="stateless">
 		<security:intercept-url pattern="/resources/**" access="permitAll"/>
 		<security:custom-filter ref="corsFilter" after="SECURITY_CONTEXT_FILTER" />
 		<security:csrf disabled="true"/>
 	</security:http>
-	
+
 	<!-- OAuth-protect API and other endpoints -->
 	<security:http pattern="/#{T(org.mitre.openid.connect.web.DynamicClientRegistrationEndpoint).URL}/**" use-expressions="true" entry-point-ref="oauthAuthenticationEntryPoint" create-session="stateless">
 		<security:custom-filter ref="resourceServerFilter" before="PRE_AUTH_FILTER" />
@@ -169,10 +177,10 @@
 		<security:expression-handler ref="oauthWebExpressionHandler" />
 		<security:csrf disabled="true"/>
 	</security:http>
-	
- 	<security:http pattern="/#{T(org.mitre.oauth2.web.DeviceEndpoint).URL}/**" 
- 		use-expressions="true" 
- 		entry-point-ref="oauthAuthenticationEntryPoint" 
+
+ 	<security:http pattern="/#{T(org.mitre.oauth2.web.DeviceEndpoint).URL}/**"
+ 		use-expressions="true"
+ 		entry-point-ref="oauthAuthenticationEntryPoint"
  		create-session="stateless"
  		authentication-manager-ref="clientAuthenticationManager">
 		<security:http-basic entry-point-ref="oauthAuthenticationEntryPoint" />
@@ -183,10 +191,10 @@
 		<security:access-denied-handler ref="oauthAccessDeniedHandler" />
 		<security:csrf disabled="true"/>
 	</security:http>
-	
-	<security:http pattern="/#{T(org.mitre.oauth2.web.IntrospectionEndpoint).URL}**" 
-			use-expressions="true" 
-			entry-point-ref="oauthAuthenticationEntryPoint" 
+
+	<security:http pattern="/#{T(org.mitre.oauth2.web.IntrospectionEndpoint).URL}**"
+			use-expressions="true"
+			entry-point-ref="oauthAuthenticationEntryPoint"
 			create-session="stateless"
 			authentication-manager-ref="clientAuthenticationManager">
 		<security:http-basic entry-point-ref="oauthAuthenticationEntryPoint" />
@@ -198,8 +206,8 @@
 	</security:http>
 
 	<security:http pattern="/#{T(org.mitre.oauth2.web.RevocationEndpoint).URL}**"
-			use-expressions="true" 
-			entry-point-ref="oauthAuthenticationEntryPoint" 
+			use-expressions="true"
+			entry-point-ref="oauthAuthenticationEntryPoint"
 			create-session="stateless"
 			authentication-manager-ref="clientAuthenticationManager">
 		<security:http-basic entry-point-ref="oauthAuthenticationEntryPoint" />
@@ -217,7 +225,7 @@
 	<bean id="http403EntryPoint" class="org.springframework.security.web.authentication.Http403ForbiddenEntryPoint" />
 
 	<!-- Additional endpoints for extensions (such as UMA) -->
-	
+
 	<import resource="endpoint-config.xml" />
 
 	<!-- SECOAUTH Authorization Server -->
@@ -240,7 +248,7 @@
 		<property name="authenticationManager" ref="clientAuthenticationManager" />
 		<property name="requiresAuthenticationRequestMatcher" ref="clientAuthMatcher" />
 	</bean>
-	
+
 	<bean id="clientAssertionEndpointFilter" class="org.mitre.openid.connect.assertion.JWTBearerClientAssertionTokenEndpointFilter">
 		<constructor-arg name="additionalMatcher" ref="clientAuthMatcher" />
 		<property name="authenticationManager" ref="clientAssertionAuthenticationManager" />
@@ -254,7 +262,7 @@
 	<security:authentication-manager id="clientAssertionAuthenticationManager">
 		<security:authentication-provider ref="clientAssertionAuthenticationProvider" />
 	</security:authentication-manager>
-	
+
 	<bean id="clientAssertionAuthenticationProvider" class="org.mitre.openid.connect.assertion.JWTBearerAuthenticationProvider" />
 
 	<!-- Configure locale information -->
@@ -262,7 +270,7 @@
 
 	<!-- user services -->
 	<import resource="user-context.xml" />
-	
+
 	<!-- assertion processing -->
 	<import resource="assertion-config.xml" />
 
@@ -282,11 +290,11 @@
 
 	<!-- View configuration -->
 
-	<!-- Handles HTTP GET requests for /resources/** by efficiently serving 
+	<!-- Handles HTTP GET requests for /resources/** by efficiently serving
 		up static resources in the ${webappRoot}/resources directory -->
 	<mvc:resources mapping="/resources/**" location="/resources/" />
 
-	<!-- Resolves views selected for rendering by @Controllers to .jsp resources 
+	<!-- Resolves views selected for rendering by @Controllers to .jsp resources
 		in the /WEB-INF/views directory -->
 	<bean class="org.springframework.web.servlet.view.InternalResourceViewResolver">
 		<property name="viewClass" value="org.springframework.web.servlet.view.JstlView" />
@@ -304,7 +312,7 @@
 
 	<!--Import scheduled task configuration -->
 	<import resource="task-config.xml" />
-	
+
 	<!-- Import configuration for front-end (JavaScript) UI components -->
 	<import resource="ui-config.xml" />
 

--- a/openid-connect-server-webapp/src/main/webapp/WEB-INF/data-context.xml
+++ b/openid-connect-server-webapp/src/main/webapp/WEB-INF/data-context.xml
@@ -57,7 +57,7 @@
       <property name="jdbcUrl" value="${jdbc.url}" />
 			<property name="username" value="${jdbc.username}" />
 			<property name="password" value="${jdbc.password}" />
-    </bean> -->
+    </bean>
 
     <bean id="jpaAdapter" class="org.springframework.orm.jpa.vendor.EclipseLinkJpaVendorAdapter">
       <property name="databasePlatform" value="org.eclipse.persistence.platform.database.MySQLPlatform" />
@@ -66,7 +66,7 @@
 
 	<!-- You can optionally initialize the database with test values here,
 		but this is not recommended for real systems -->
-		<jdbc:initialize-database data-source="dataSource"> -->
+		<jdbc:initialize-database data-source="dataSource">
 			<jdbc:script location="classpath:/db/tables/mysql_database_tables.sql"/>
 			<jdbc:script location="classpath:/db/tables/security-schema.sql"/>
 			<jdbc:script location="classpath:/db/tables/loading_temp_tables.sql"/>

--- a/openid-connect-server-webapp/src/main/webapp/WEB-INF/data-context.xml
+++ b/openid-connect-server-webapp/src/main/webapp/WEB-INF/data-context.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2017 The MIT Internet Trust Consortium
-   
+
     Portions copyright 2011-2013 The MITRE Corporation
-   
+
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
-   
+
       http://www.apache.org/licenses/LICENSE-2.0
-   
+
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,107 +22,112 @@
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.3.xsd
        						http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc-4.3.xsd">
 
-	<bean id="dataSource" class="com.zaxxer.hikari.HikariDataSource" destroy-method="close">
-		<property name="driverClassName" value="org.hsqldb.jdbcDriver" />
-		<property name="jdbcUrl" value="jdbc:hsqldb:mem:oic;sql.syntax_mys=true" />
-<!-- 		<property name="jdbcUrl" value="jdbc:hsqldb:file:/tmp/oic;sql.syntax_mys=true" /> -->
-		<property name="username" value="oic" />
-		<property name="password" value="oic" />
-	</bean>
+  <beans profile="hsqldb">
+		<bean id="dataSource" class="com.zaxxer.hikari.HikariDataSource" destroy-method="close">
+			<property name="driverClassName" value="org.hsqldb.jdbcDriver" />
+			<property name="jdbcUrl" value="${jdbc.url}" />
+			<property name="username" value="${jdbc.username}" />
+			<property name="password" value="${jdbc.password}" />
+		</bean>
 
-	<!-- Use the following to set up the OIC tables in the in-memory DB
- 		   If you are using a file based HSQLDB you should not run this every time. -->
-	<jdbc:initialize-database data-source="dataSource">
-		<jdbc:script location="classpath:/db/hsql/hsql_database_tables.sql"/>
-		<!-- The following file is for the jdbc-user-service spring security implementation -->
-		<jdbc:script location="classpath:/db/hsql/security-schema.sql"/>
-		<!-- The following files are for safely bootstrapping users and clients into the database -->
-		<jdbc:script location="classpath:/db/hsql/loading_temp_tables.sql"/>
-		<jdbc:script location="classpath:/db/hsql/users.sql"/>
-		<jdbc:script location="classpath:/db/hsql/clients.sql"/>
-		<jdbc:script location="classpath:/db/hsql/scopes.sql"/>
-	</jdbc:initialize-database>
+		<!-- Use the following to set up the OIC tables in the in-memory DB
+	 		   If you are using a file based HSQLDB you should not run this every time. -->
+		<jdbc:initialize-database data-source="dataSource">
+			<jdbc:script location="classpath:/db/hsql/hsql_database_tables.sql"/>
+			<!-- The following file is for the jdbc-user-service spring security implementation -->
+			<jdbc:script location="classpath:/db/hsql/security-schema.sql"/>
+			<!-- The following files are for safely bootstrapping users and clients into the database -->
+			<jdbc:script location="classpath:/db/hsql/loading_temp_tables.sql"/>
+			<jdbc:script location="classpath:/db/hsql/users.sql"/>
+			<jdbc:script location="classpath:/db/hsql/clients.sql"/>
+			<jdbc:script location="classpath:/db/hsql/scopes.sql"/>
+		</jdbc:initialize-database>
 
-	<bean id="jpaAdapter" class="org.springframework.orm.jpa.vendor.EclipseLinkJpaVendorAdapter">
- 		<property name="databasePlatform" value="org.eclipse.persistence.platform.database.HSQLPlatform" />
-		<property name="showSql" value="true" />
-	</bean>
+		<bean id="jpaAdapter" class="org.springframework.orm.jpa.vendor.EclipseLinkJpaVendorAdapter">
+	 		<property name="databasePlatform" value="org.eclipse.persistence.platform.database.HSQLPlatform" />
+			<property name="showSql" value="true" />
+		</bean>
+	</beans>
 
-	<!--  The following is for connecting to a MySQL database that has been initialized with 
+	<!--  The following is for connecting to a MySQL database that has been initialized with
 			src/main/resources/db/mysql/mysql_database_tables.sql -->
-<!-- 	<bean id="dataSource" class="com.zaxxer.hikari.HikariDataSource" destroy-method="close"> -->
-<!-- 		<property name="driverClassName" value="com.mysql.jdbc.Driver" /> -->
-<!-- 		<property name="jdbcUrl" value="jdbc:mysql://127.0.0.1:3306/oic" /> -->
-<!-- 		<property name="username" value="oic" /> -->
-<!-- 		<property name="password" value="oic" /> -->
-<!--  	</bean> -->
+	<beans profile="mysql">
+  	<bean id="dataSource" class="com.zaxxer.hikari.HikariDataSource" destroy-method="close">
+      <property name="driverClassName" value="com.mysql.jdbc.Driver" />
+      <property name="jdbcUrl" value="${jdbc.url}" />
+			<property name="username" value="${jdbc.username}" />
+			<property name="password" value="${jdbc.password}" />
+    </bean> -->
 
-<!-- 	<bean id="jpaAdapter" class="org.springframework.orm.jpa.vendor.EclipseLinkJpaVendorAdapter"> -->
-<!-- 		<property name="databasePlatform" value="org.eclipse.persistence.platform.database.MySQLPlatform" /> -->
-<!-- 		<property name="showSql" value="true" /> -->
-<!-- 	</bean> -->
+    <bean id="jpaAdapter" class="org.springframework.orm.jpa.vendor.EclipseLinkJpaVendorAdapter">
+      <property name="databasePlatform" value="org.eclipse.persistence.platform.database.MySQLPlatform" />
+      <property name="showSql" value="true" />
+    </bean>
 
-	<!-- You can optionally initialize the database with test values here, 
+	<!-- You can optionally initialize the database with test values here,
 		but this is not recommended for real systems -->
-<!-- 	<jdbc:initialize-database data-source="dataSource"> -->
-<!-- 		<jdbc:script location="classpath:/db/tables/mysql_database_tables.sql"/> -->
-<!-- 		<jdbc:script location="classpath:/db/tables/security-schema.sql"/> -->
-<!-- 		<jdbc:script location="classpath:/db/tables/loading_temp_tables.sql"/> -->
-<!-- 		<jdbc:script location="classpath:/db/mysql/users.sql"/> -->
-<!-- 		<jdbc:script location="classpath:/db/mysql/clients.sql"/> -->
-<!-- 		<jdbc:script location="classpath:/db/mysql/scopes.sql"/> -->
-<!-- 	</jdbc:initialize-database> -->
+		<jdbc:initialize-database data-source="dataSource"> -->
+			<jdbc:script location="classpath:/db/tables/mysql_database_tables.sql"/>
+			<jdbc:script location="classpath:/db/tables/security-schema.sql"/>
+			<jdbc:script location="classpath:/db/tables/loading_temp_tables.sql"/>
+			<jdbc:script location="classpath:/db/mysql/users.sql"/>
+			<jdbc:script location="classpath:/db/mysql/clients.sql"/>
+			<jdbc:script location="classpath:/db/mysql/scopes.sql"/>
+	  </jdbc:initialize-database>
+	</beans>
 
 	<!--  The following is for connecting to a PostgreSQL database that has been initialized with
 			src/main/resources/db/psql/psql_database_tables.sql -->
-	<!--
-	<bean id="dataSource" class="com.zaxxer.hikari.HikariDataSource" destroy-method="close">
-		<property name="driverClassName" value="org.postgresql.Driver" />
-		<property name="jdbcUrl" value="jdbc:postgresql://localhost/oic" />
-		<property name="username" value="oic" />
-		<property name="password" value="oic" />
-	</bean>
+	<beans profile="postgresql">
+		<bean id="dataSource" class="com.zaxxer.hikari.HikariDataSource" destroy-method="close">
+			<property name="driverClassName" value="org.postgresql.Driver" />
+			<property name="jdbcUrl" value="${jdbc.url}" />
+			<property name="username" value="${jdbc.username}" />
+			<property name="password" value="${jdbc.password}" />
+		</bean>
 
+		<bean id="jpaAdapter" class="org.springframework.orm.jpa.vendor.EclipseLinkJpaVendorAdapter">
+			<property name="databasePlatform" value="org.eclipse.persistence.platform.database.PostgreSQLPlatform" />
+			<property name="showSql" value="true" />
+		</bean>
 
-	<bean id="jpaAdapter" class="org.springframework.orm.jpa.vendor.EclipseLinkJpaVendorAdapter">
-		<property name="databasePlatform" value="org.eclipse.persistence.platform.database.PostgreSQLPlatform" />
-		<property name="showSql" value="true" />
-	</bean>
-	-->
-	
-	<!-- You can optionally initialize the database with test values here, 
-		but this is not recommended for real systems -->
-<!-- 	<jdbc:initialize-database data-source="dataSource"> -->
-<!-- 		<jdbc:script location="classpath:/db/psql/psql_database_tables.sql"/> -->
-<!-- 		<jdbc:script location="classpath:/db/psql/security-schema.sql"/> -->
-<!-- 		<jdbc:script location="classpath:/db/psql/loading_temp_tables.sql"/> -->
-<!-- 		<jdbc:script location="classpath:/db/psql/users.sql"/> -->
-<!-- 		<jdbc:script location="classpath:/db/psql/clients.sql"/> -->
-<!-- 		<jdbc:script location="classpath:/db/psql/scopes.sql"/> -->
-<!-- 	</jdbc:initialize-database> -->
+		<!-- You can optionally initialize the database with test values here,
+			but this is not recommended for real systems -->
+	 	<jdbc:initialize-database data-source="dataSource">
+	 		<jdbc:script location="classpath:/db/psql/psql_database_tables.sql"/>
+	 		<jdbc:script location="classpath:/db/psql/security-schema.sql"/>
+	 		<jdbc:script location="classpath:/db/psql/loading_temp_tables.sql"/>
+			<jdbc:script location="classpath:/db/psql/users.sql"/>
+			<jdbc:script location="classpath:/db/psql/clients.sql"/>
+	 		<jdbc:script location="classpath:/db/psql/scopes.sql"/>
+		</jdbc:initialize-database>
+	</beans>
 
 	<!--  The following is for connecting to a Oracle database that has been initialized with
 			src/main/resources/db/oracle/oracle_database_tables.sql -->
-	<!--<bean id="dataSource" class="com.zaxxer.hikari.HikariDataSource" destroy-method="close">
-		<property name="driverClassName" value="oracle.jdbc.driver.OracleDriver" />
-		<property name="jdbcUrl" value="jdbc:oracle:thin:@localhost:1521:XE" />
-		<property name="username" value="oic" />
-		<property name="password" value="oic" />
-	</bean>-->
+	<beans profile="oracle">
+		<bean id="dataSource" class="com.zaxxer.hikari.HikariDataSource" destroy-method="close">
+			<property name="driverClassName" value="oracle.jdbc.driver.OracleDriver" />
+			<property name="jdbcUrl" value="${jdbc.url}" />
+			<property name="username" value="${jdbc.username}" />
+			<property name="password" value="${jdbc.password}" />
+		</bean>
 
-	<!--<bean id="jpaAdapter" class="org.springframework.orm.jpa.vendor.EclipseLinkJpaVendorAdapter">
-		<property name="databasePlatform" value="org.eclipse.persistence.platform.database.OraclePlatform" />
-		<property name="showSql" value="true" />
-	</bean>-->
+		<bean id="jpaAdapter" class="org.springframework.orm.jpa.vendor.EclipseLinkJpaVendorAdapter">
+			<property name="databasePlatform" value="org.eclipse.persistence.platform.database.OraclePlatform" />
+			<property name="showSql" value="true" />
+		</bean>
 
 	<!-- Use the following to set up the OIC tables in the Oracle DB
 		   Below scripts are intended to be run once at startup. -->
-	<!--<jdbc:initialize-database data-source="dataSource">
-		<jdbc:script location="classpath:/db/oracle/oracle_database_tables.sql"/>
-		<jdbc:script location="classpath:/db/oracle/security-schema_oracle.sql"/>
-		<jdbc:script location="classpath:/db/oracle/loading_temp_tables_oracle.sql"/>
-		<jdbc:script location="classpath:/db/oracle/users_oracle.sql"/>
-		<jdbc:script location="classpath:/db/oracle/clients_oracle.sql"/>
-		<jdbc:script location="classpath:/db/oracle/scopes_oracle.sql"/>
-	</jdbc:initialize-database>-->
+		<jdbc:initialize-database data-source="dataSource">
+			<jdbc:script location="classpath:/db/oracle/oracle_database_tables.sql"/>
+			<jdbc:script location="classpath:/db/oracle/security-schema_oracle.sql"/>
+			<jdbc:script location="classpath:/db/oracle/loading_temp_tables_oracle.sql"/>
+			<jdbc:script location="classpath:/db/oracle/users_oracle.sql"/>
+			<jdbc:script location="classpath:/db/oracle/clients_oracle.sql"/>
+			<jdbc:script location="classpath:/db/oracle/scopes_oracle.sql"/>
+		</jdbc:initialize-database>
+	</beans>
+
 </beans>

--- a/openid-connect-server-webapp/src/main/webapp/WEB-INF/server-config.xml
+++ b/openid-connect-server-webapp/src/main/webapp/WEB-INF/server-config.xml
@@ -33,7 +33,7 @@
 	<bean id="configBean" class="org.mitre.openid.connect.config.ConfigurationPropertiesBean">
 	    
 	    <!-- This property sets the root URL of the server, known as the issuer -->
-		<property name="issuer" value="http://localhost:8080/openid-connect-server-webapp/" />
+		<property name="issuer" value="${openid.issuer}" />
 		
 		<!-- This property is a URL pointing to a logo image 24px high to be used in the top bar -->
  		<property name="logoImageUrl" value="resources/images/openid_connect_small.png" />

--- a/openid-connect-server-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/openid-connect-server-webapp/src/main/webapp/WEB-INF/web.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2017 The MIT Internet Trust Consortium
-   
+
     Portions copyright 2011-2013 The MITRE Corporation
-   
+
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
-   
+
       http://www.apache.org/licenses/LICENSE-2.0
-   
+
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,13 +23,18 @@
 
 	<absolute-ordering />
 
-	<!-- The definition of the Root Spring Container shared by all Servlets 
+	<!-- The definition of the Root Spring Container shared by all Servlets
 		and Filters -->
 	<context-param>
 		<param-name>contextConfigLocation</param-name>
 		<param-value>
 			/WEB-INF/application-context.xml
 		</param-value>
+	</context-param>
+	
+	<context-param>
+ 		<param-name>spring.profiles.active</param-name>
+ 		<param-value>hsqldb</param-value>
 	</context-param>
 
 	<!-- Creates the Spring Container shared by all Servlets and Filters -->
@@ -71,9 +76,9 @@
 			<trim-directive-whitespaces>true</trim-directive-whitespaces>
 		</jsp-property-group>
 	</jsp-config>
-	
+
 	<error-page>
 		<location>/error</location>
 	</error-page>
-	
+
 </web-app>


### PR DESCRIPTION
Configuration of openid issuer and database are moved to openid.properties file.

Usage of spring profile to select database. Right now it's defined in web.xml but can be passed as a java options to Tomcat.