### PR TITLE
add UNIQUE constraints on user_info email and preferred_username

### DIFF
--- a/openid-connect-server-webapp/src/main/resources/db/hsql/hsql_database_tables.sql
+++ b/openid-connect-server-webapp/src/main/resources/db/hsql/hsql_database_tables.sql
@@ -264,7 +264,9 @@ CREATE TABLE IF NOT EXISTS user_info (
 	address_id VARCHAR(256),
 	updated_time VARCHAR(256),
 	birthdate VARCHAR(256),
-	src VARCHAR(4096)
+	src VARCHAR(4096),
+	UNIQUE(preferred_username),
+	UNIQUE(email)
 );
 
 CREATE TABLE IF NOT EXISTS whitelisted_site (

--- a/openid-connect-server-webapp/src/main/resources/db/mysql/mysql_database_tables.sql
+++ b/openid-connect-server-webapp/src/main/resources/db/mysql/mysql_database_tables.sql
@@ -263,7 +263,9 @@ CREATE TABLE IF NOT EXISTS user_info (
 	address_id VARCHAR(256),
 	updated_time VARCHAR(256),
 	birthdate VARCHAR(256),
-	src VARCHAR(4096)
+	src VARCHAR(4096),
+	UNIQUE(preferred_username),
+	UNIQUE(email)
 );
 
 CREATE TABLE IF NOT EXISTS whitelisted_site (

--- a/openid-connect-server-webapp/src/main/resources/db/oracle/oracle_database_tables.sql
+++ b/openid-connect-server-webapp/src/main/resources/db/oracle/oracle_database_tables.sql
@@ -291,7 +291,9 @@ CREATE TABLE user_info (
   src VARCHAR2(4000),
 
   CONSTRAINT email_verified_check CHECK (email_verified in (1,0)),
-  CONSTRAINT phone_number_verified_check CHECK (phone_number_verified in (1,0))
+  CONSTRAINT phone_number_verified_check CHECK (phone_number_verified in (1,0)),
+  CONSTRAINT user_info_username_unique UNIQUE (preferred_username),
+  CONSTRAINT user_info_email_unique UNIQUE (email)
 );
 CREATE SEQUENCE user_info_seq START WITH 1 INCREMENT BY 1 NOCACHE NOCYCLE;
 

--- a/openid-connect-server-webapp/src/main/resources/db/psql/psql_database_tables.sql
+++ b/openid-connect-server-webapp/src/main/resources/db/psql/psql_database_tables.sql
@@ -266,7 +266,9 @@ CREATE TABLE IF NOT EXISTS user_info (
 	address_id VARCHAR(256),
 	updated_time VARCHAR(256),
 	birthdate VARCHAR(256),
-	src VARCHAR(4096)
+	src VARCHAR(4096),
+	UNIQUE(preferred_username),
+	UNIQUE(email)
 );
 
 CREATE TABLE IF NOT EXISTS whitelisted_site (


### PR DESCRIPTION
fixes #1275 

Fortunately all four databases treat `NULL`s the same way for `UNIQUE` constraints (multiple rows with `NULL`s are allowed), doing the same for MS-SQL would have been harder.

I've only tested the hsql and postgres versions myself.