### PR TITLE
add unique constraints to stop client_* tables from growing out of bounds

### DIFF
--- a/openid-connect-server-webapp/src/main/resources/db/mysql/mysql_database_tables.sql
+++ b/openid-connect-server-webapp/src/main/resources/db/mysql/mysql_database_tables.sql
@@ -108,8 +108,9 @@ CREATE TABLE IF NOT EXISTS authorization_code (
 );
 
 CREATE TABLE IF NOT EXISTS client_grant_type (
-	owner_id BIGINT,
-	grant_type VARCHAR(2000)
+	owner_id BIGINT NOT NULL,
+	grant_type VARCHAR(2000),
+        UNIQUE (owner_id, grant_type)
 );
 
 CREATE TABLE IF NOT EXISTS client_response_type (
@@ -199,8 +200,9 @@ CREATE TABLE IF NOT EXISTS client_contact (
 );
 
 CREATE TABLE IF NOT EXISTS client_redirect_uri (
-	owner_id BIGINT, 
-	redirect_uri VARCHAR(2048) 
+	owner_id BIGINT NOT NULL,
+	redirect_uri VARCHAR(2048),
+        UNIQUE (owner_id, redirect_uri)
 );
 
 CREATE TABLE IF NOT EXISTS client_claims_redirect_uri (
@@ -222,8 +224,9 @@ CREATE TABLE IF NOT EXISTS client_resource (
 );
 
 CREATE TABLE IF NOT EXISTS client_scope (
-	owner_id BIGINT,
-	scope VARCHAR(2048)
+	owner_id BIGINT NOT NULL,
+	scope VARCHAR(2048),
+        UNIQUE (owner_id, scope)
 );
 
 CREATE TABLE IF NOT EXISTS token_scope (

--- a/openid-connect-server-webapp/src/main/resources/db/psql/psql_database_tables.sql
+++ b/openid-connect-server-webapp/src/main/resources/db/psql/psql_database_tables.sql
@@ -109,8 +109,9 @@ CREATE TABLE IF NOT EXISTS authorization_code (
 );
 
 CREATE TABLE IF NOT EXISTS client_grant_type (
-	owner_id BIGINT,
-	grant_type VARCHAR(2000)
+	owner_id BIGINT NOT NULL,
+	grant_type VARCHAR(2000),
+        UNIQUE (owner_id, grant_type)
 );
 
 CREATE TABLE IF NOT EXISTS client_response_type (
@@ -200,8 +201,9 @@ CREATE TABLE IF NOT EXISTS client_contact (
 );
 
 CREATE TABLE IF NOT EXISTS client_redirect_uri (
-	owner_id BIGINT,
-	redirect_uri VARCHAR(2048)
+	owner_id BIGINT NOT NULL,
+	redirect_uri VARCHAR(2048),
+        UNIQUE (owner_id, redirect_uri)
 );
 
 CREATE TABLE IF NOT EXISTS client_claims_redirect_uri (
@@ -223,8 +225,9 @@ CREATE TABLE IF NOT EXISTS client_resource (
 );
 
 CREATE TABLE IF NOT EXISTS client_scope (
-	owner_id BIGINT,
-	scope VARCHAR(2048)
+	owner_id BIGINT NOT NULL,
+	scope VARCHAR(2048),
+        UNIQUE (owner_id, scope)
 );
 
 CREATE TABLE IF NOT EXISTS token_scope (


### PR DESCRIPTION
In our dev environments where we provision clients via a `clients.sql` script three of the `client_` grew with every service restart. The reason is the code assumes entries in that table to be unique while in fact they are not (at the DB level).

I've added unique constraints for postgres and mysql only as I think the `merge` commands used for hsql and oracle should already avoid growing those tables.