### PR TITLE
Client: Parse 'sub' key to identify resource owner in introspection response (RFC7662)

### DIFF
--- a/openid-connect-client/src/main/java/org/mitre/oauth2/introspectingfilter/IntrospectingTokenService.java
+++ b/openid-connect-client/src/main/java/org/mitre/oauth2/introspectingfilter/IntrospectingTokenService.java
@@ -244,7 +244,10 @@ public class IntrospectingTokenService implements ResourceServerTokenServices {
 	private Authentication createUserAuthentication(JsonObject token) {
 		JsonElement userId = token.get("user_id");
 		if(userId == null) {
-			return null;
+			userId = token.get("sub");
+			if (userId == null) {
+				return null;
+			}
 		}
 
 		return new PreAuthenticatedAuthenticationToken(userId.getAsString(), token, introspectionAuthorityGranter.getAuthorities(token));


### PR DESCRIPTION
First of all: Thanks for your work! Getting the OpenID Connect client library to work was surprisingly easy. 

As per https://tools.ietf.org/html/rfc7662#section-2.2 the `sub` key should identify the resource owner in oauth2 introspection responses:

>    sub
      OPTIONAL.  Subject of the token, as defined in JWT [RFC7519].
      Usually a machine-readable identifier of the resource owner who
      authorized this token.

I've found that this OpenID Connect client library checks for the (non-standard?) `user_id` key, which prevents responses from RFC-compliant servers to be parsed. 

This pull request adds support for the `sub` key and will allow the introspection response of RFC-compliant servers to be parsed. Will still try `user_id` first as to not break backward compatibility.