### PR TITLE
Add GrantedAuthority converter to avoid errors when client has authorities

### DIFF
--- a/openid-connect-common/src/main/java/org/mitre/oauth2/model/convert/GrantedAuthorityJsonConverter.java
+++ b/openid-connect-common/src/main/java/org/mitre/oauth2/model/convert/GrantedAuthorityJsonConverter.java
@@ -1,0 +1,17 @@
+package org.mitre.oauth2.model.convert;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import com.google.gson.JsonElement;
+
+public class GrantedAuthorityJsonConverter {
+
+    private static final String ROLE_MEMBER_NAME = "role";
+
+    private GrantedAuthorityJsonConverter() { }
+
+    public static GrantedAuthority parse(JsonElement jsonElement) {
+        return new SimpleGrantedAuthority(jsonElement.getAsJsonObject().get(ROLE_MEMBER_NAME).getAsString());
+    }
+}

--- a/openid-connect-common/src/test/java/org/mitre/oauth2/model/convert/GrantedAuthorityJsonConverterTest.java
+++ b/openid-connect-common/src/test/java/org/mitre/oauth2/model/convert/GrantedAuthorityJsonConverterTest.java
@@ -1,0 +1,25 @@
+package org.mitre.oauth2.model.convert;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.springframework.security.core.GrantedAuthority;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+public class GrantedAuthorityJsonConverterTest {
+    
+    @Test
+    public void parse() {
+        
+        final JsonParser parser = new JsonParser();
+        final JsonObject jsonObject = parser.parse("{\"role\": \"ROLE_CLIENT\"}").getAsJsonObject();
+        
+        final GrantedAuthority authority = GrantedAuthorityJsonConverter.parse(jsonObject);
+        
+        assertEquals("ROLE_CLIENT", authority.getAuthority());
+        
+    }
+    
+}

--- a/openid-connect-server/src/main/java/org/mitre/openid/connect/web/ClientAPI.java
+++ b/openid-connect-server/src/main/java/org/mitre/openid/connect/web/ClientAPI.java
@@ -31,6 +31,7 @@ import org.mitre.oauth2.model.ClientDetailsEntity.AppType;
 import org.mitre.oauth2.model.ClientDetailsEntity.AuthMethod;
 import org.mitre.oauth2.model.ClientDetailsEntity.SubjectType;
 import org.mitre.oauth2.model.PKCEAlgorithm;
+import org.mitre.oauth2.model.convert.GrantedAuthorityJsonConverter;
 import org.mitre.oauth2.service.ClientDetailsEntityService;
 import org.mitre.oauth2.web.AuthenticationUtilities;
 import org.mitre.openid.connect.exception.ValidationException;
@@ -51,6 +52,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.oauth2.common.util.OAuth2Utils;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -212,6 +214,12 @@ public class ClientAPI {
 					}
 				}
 			})
+			.registerTypeAdapter(GrantedAuthority.class, new JsonDeserializer<GrantedAuthority>() {
+                @Override
+                public GrantedAuthority deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+                    return GrantedAuthorityJsonConverter.parse(json);
+                }
+            })
 			.setDateFormat("yyyy-MM-dd'T'HH:mm:ssZ")
 			.create();
 


### PR DESCRIPTION
Good afternoon.

The following request resolves an error that occurs when the detail of a client is consulted and it has associated roles.

This is because the json deserialiser is not capable of generating the GrantedAthorities through the json received at the controller.

The error has been solved by associating a converter to the gson builder that will be responsible for transofromating the json to Java classes.
