### PR TITLE
Feature to set encoder password for users and clients

### DIFF
--- a/openid-connect-server-webapp/src/main/webapp/WEB-INF/crypto-config.xml
+++ b/openid-connect-server-webapp/src/main/webapp/WEB-INF/crypto-config.xml
@@ -46,5 +46,35 @@
 		<property name="defaultDecryptionKeyId" value="rsa1" />
 		<property name="defaultEncryptionKeyId" value="rsa1" />
 	</bean>
+    
+    <!-- Use following password encoder for saving client passwords as plain text -->
+    <bean id="clientPasswordEncoder" class="org.springframework.security.crypto.password.NoOpPasswordEncoder" />
+    
+    <!-- Use following password encoder for saving client passwords encoded with BCrypt algorithm -->
+    <!-- <bean id="clientPasswordEncoder" class="org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder" /> -->
+    
+    <!-- Use following password encoder for saving client passwords encoded with PBKDF2 algorithm -->
+    <!-- <bean id="clientPasswordEncoder" class="org.springframework.security.crypto.password.Pbkdf2PasswordEncoder" /> -->
+    
+    <!-- Use following password encoder for saving client passwords encoded with SCrypt algorithm -->
+    <!-- <bean id="clientPasswordEncoder" class="org.springframework.security.crypto.scrypt.SCryptPasswordEncoder" /> -->
+    
+    <!-- Use following password encoder for saving client passwords encoded with Standard algorithm -->
+    <!-- <bean id="clientPasswordEncoder" class="org.springframework.security.crypto.password.StandardPasswordEncoder" /> -->
+        
+    <!-- Use following password encoder for saving user passwords as plain text -->
+    <bean id="userPasswordEncoder" class="org.springframework.security.crypto.password.NoOpPasswordEncoder" />
+    
+    <!-- Use following password encoder for saving user passwords encoded with BCrypt algorithm -->
+    <!-- <bean id="userPasswordEncoder" class="org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder" /> -->
+    
+    <!-- Use following password encoder for saving user passwords encoded with PBKDF2 algorithm -->
+    <!-- <bean id="userPasswordEncoder" class="org.springframework.security.crypto.password.Pbkdf2PasswordEncoder" /> -->
+    
+    <!-- Use following password encoder for saving user passwords encoded with SCrypt algorithm -->
+    <!-- <bean id="userPasswordEncoder" class="org.springframework.security.crypto.scrypt.SCryptPasswordEncoder" /> -->
+    
+    <!-- Use following password encoder for saving user passwords encoded with Standard algorithm -->
+    <!-- <bean id="userPasswordEncoder" class="org.springframework.security.crypto.password.StandardPasswordEncoder" /> -->
 
 </beans>

--- a/openid-connect-server-webapp/src/main/webapp/WEB-INF/user-context.xml
+++ b/openid-connect-server-webapp/src/main/webapp/WEB-INF/user-context.xml
@@ -32,6 +32,7 @@
 
 	<security:authentication-manager id="authenticationManager">
 		<security:authentication-provider>
+            <security:password-encoder ref="userPasswordEncoder"/>
 			<security:jdbc-user-service data-source-ref="dataSource"/>
 		</security:authentication-provider>
 	</security:authentication-manager>

--- a/openid-connect-server/src/main/java/org/mitre/oauth2/service/impl/DefaultOAuth2ClientDetailsEntityService.java
+++ b/openid-connect-server/src/main/java/org/mitre/oauth2/service/impl/DefaultOAuth2ClientDetailsEntityService.java
@@ -19,7 +19,12 @@ package org.mitre.oauth2.service.impl;
 
 import java.math.BigInteger;
 import java.security.SecureRandom;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
@@ -424,9 +429,7 @@ public class DefaultOAuth2ClientDetailsEntityService implements ClientDetailsEnt
 			ensureNoReservedScopes(newClient);
 			
 			// encode password
-            if (!hasOldClientSamePasswordAsNewClient(oldClient, newClient)) {
-                newClient.setClientSecret(encodePassword(newClient));
-            }
+            newClient.setClientSecret(encodePassword(newClient));
 
 			return clientRepository.updateClient(oldClient.getId(), newClient);
 		}
@@ -463,26 +466,6 @@ public class DefaultOAuth2ClientDetailsEntityService implements ClientDetailsEnt
 		}
 		return client;
 	}
-	
-	/**
-	 * Compares client secrets between old and new client. 
-	 * @param oldClient {@link ClientDetailsEntity} with old client data
-	 * @param newClient {@link ClientDetailsEntity} with new client data
-	 * @return returns true if both client secrets are equals and returns false if they are different
-	 */
-	private boolean hasOldClientSamePasswordAsNewClient(ClientDetailsEntity oldClient, ClientDetailsEntity newClient) {
-
-        final String oldClientSecret = oldClient.getClientSecret();
-        final String newClientSecret = oldClient.getClientSecret();
-        
-        if (oldClientSecret == null && newClientSecret == null) {
-            return Boolean.TRUE;
-        } else if (oldClientSecret == null || newClientSecret == null) {
-            return Boolean.FALSE;
-        } 
-	    
-        return oldClientSecret.equals(newClientSecret);
-    }
 	
 	/**
 	 * Returns client secret encoded by configured password encoder.

--- a/openid-connect-server/src/test/java/org/mitre/oauth2/service/impl/TestDefaultOAuth2ClientDetailsEntityService.java
+++ b/openid-connect-server/src/test/java/org/mitre/oauth2/service/impl/TestDefaultOAuth2ClientDetailsEntityService.java
@@ -17,6 +17,14 @@
  *******************************************************************************/
 package org.mitre.oauth2.service.impl;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.anyString;
+
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -38,25 +46,14 @@ import org.mitre.openid.connect.service.StatsService;
 import org.mitre.openid.connect.service.WhitelistedSiteService;
 import org.mitre.uma.model.ResourceSet;
 import org.mitre.uma.service.ResourceSetService;
-import org.mockito.AdditionalAnswers;
-import org.mockito.InjectMocks;
-import org.mockito.Matchers;
-import org.mockito.Mock;
-import org.mockito.Mockito;
+import org.mockito.*;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.common.exceptions.InvalidClientException;
 
 import com.google.common.collect.Sets;
-
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
-
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
 
 /**
  * @author wkim
@@ -89,15 +86,18 @@ public class TestDefaultOAuth2ClientDetailsEntityService {
 	@Mock
 	private StatsService statsService;
 
-	@Mock
-	private ConfigurationPropertiesBean config;
+    @Mock
+    private ConfigurationPropertiesBean config;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
 
 	@InjectMocks
 	private DefaultOAuth2ClientDetailsEntityService service;
 
 	@Before
 	public void prepare() {
-		Mockito.reset(clientRepository, tokenRepository, approvedSiteService, whitelistedSiteService, blacklistedSiteService, scopeService, statsService);
+		Mockito.reset(clientRepository, tokenRepository, approvedSiteService, whitelistedSiteService, blacklistedSiteService, scopeService, statsService, passwordEncoder);
 
 		Mockito.when(clientRepository.saveClient(Matchers.any(ClientDetailsEntity.class))).thenAnswer(new Answer<ClientDetailsEntity>() {
 			@Override
@@ -145,6 +145,8 @@ public class TestDefaultOAuth2ClientDetailsEntityService {
 		Mockito.when(scopeService.removeReservedScopes(Matchers.anySet())).then(AdditionalAnswers.returnsFirstArg());
 
 		Mockito.when(config.isHeartMode()).thenReturn(false);
+		
+		Mockito.doReturn("").when(passwordEncoder).encode(anyString());
 
 	}
 


### PR DESCRIPTION
The following pull request adds a feature to the product that allows to configure a password encoder for users and another one for clients. In this way you can store the encrypted passwords instead of storing them in plain text.

By default, the NoOpPasswordEncoder is used, which stores the password as plain text.