### PR TITLE
Upgrade to Spring Security 4.2.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -386,7 +386,7 @@
 			<dependency>
 				<groupId>org.springframework.security</groupId>
 				<artifactId>spring-security-bom</artifactId>
-				<version>4.2.2.RELEASE</version>
+				<version>4.2.4.RELEASE</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>


### PR DESCRIPTION
https://spring.io/blog/2018/01/30/cve-2018-1199-spring-security-5-0-1-4-2-4-4-1-5-released

Closes #1349 