### PR TITLE
Add an index for refresh_token.token_value

### DIFF
--- a/openid-connect-server-webapp/src/main/resources/db/hsql/hsql_database_index.sql
+++ b/openid-connect-server-webapp/src/main/resources/db/hsql/hsql_database_index.sql
@@ -6,6 +6,7 @@ CREATE INDEX IF NOT EXISTS at_tv_idx ON access_token(token_value);
 CREATE INDEX IF NOT EXISTS ts_oi_idx ON token_scope(owner_id);
 CREATE INDEX IF NOT EXISTS at_exp_idx ON access_token(expiration);
 CREATE INDEX IF NOT EXISTS rf_ahi_idx ON refresh_token(auth_holder_id);
+CREATE INDEX IF NOT EXISTS rf_tv_idx ON refresh_token(token_value);
 CREATE INDEX IF NOT EXISTS cd_ci_idx ON client_details(client_id);
 CREATE INDEX IF NOT EXISTS at_ahi_idx ON access_token(auth_holder_id);
 CREATE INDEX IF NOT EXISTS aha_oi_idx ON authentication_holder_authority(owner_id);

--- a/openid-connect-server-webapp/src/main/resources/db/mysql/mysql_database_index.sql
+++ b/openid-connect-server-webapp/src/main/resources/db/mysql/mysql_database_index.sql
@@ -6,6 +6,7 @@ CREATE INDEX at_tv_idx ON access_token(token_value(767));
 CREATE INDEX ts_oi_idx ON token_scope(owner_id);
 CREATE INDEX at_exp_idx ON access_token(expiration);
 CREATE INDEX rf_ahi_idx ON refresh_token(auth_holder_id);
+CREATE INDEX rf_tv_idx ON refresh_token(token_value(105));
 CREATE INDEX cd_ci_idx ON client_details(client_id);
 CREATE INDEX at_ahi_idx ON access_token(auth_holder_id);
 CREATE INDEX aha_oi_idx ON authentication_holder_authority(owner_id);

--- a/openid-connect-server-webapp/src/main/resources/db/oracle/oracle_database_index.sql
+++ b/openid-connect-server-webapp/src/main/resources/db/oracle/oracle_database_index.sql
@@ -6,6 +6,7 @@ CREATE INDEX at_tv_idx ON access_token(token_value);
 CREATE INDEX ts_oi_idx ON token_scope(owner_id);
 CREATE INDEX at_exp_idx ON access_token(expiration);
 CREATE INDEX rf_ahi_idx ON refresh_token(auth_holder_id);
+CREATE INDEX rf_tv_idx ON refresh_token(token_value);
 CREATE INDEX at_ahi_idx ON access_token(auth_holder_id);
 CREATE INDEX aha_oi_idx ON authentication_holder_authority(owner_id);
 CREATE INDEX ahe_oi_idx ON authentication_holder_extension(owner_id);

--- a/openid-connect-server-webapp/src/main/resources/db/psql/psql_database_index.sql
+++ b/openid-connect-server-webapp/src/main/resources/db/psql/psql_database_index.sql
@@ -6,6 +6,7 @@ CREATE INDEX IF NOT EXISTS at_tv_idx ON access_token(token_value);
 CREATE INDEX IF NOT EXISTS ts_oi_idx ON token_scope(owner_id);
 CREATE INDEX IF NOT EXISTS at_exp_idx ON access_token(expiration);
 CREATE INDEX IF NOT EXISTS rf_ahi_idx ON refresh_token(auth_holder_id);
+CREATE INDEX IF NOT EXISTS rf_tv_idx ON refresh_token(token_value);
 CREATE INDEX IF NOT EXISTS cd_ci_idx ON client_details(client_id);
 CREATE INDEX IF NOT EXISTS at_ahi_idx ON access_token(auth_holder_id);
 CREATE INDEX IF NOT EXISTS aha_oi_idx ON authentication_holder_authority(owner_id);


### PR DESCRIPTION
As the number of users started to grow, 'refresh token select' appeared in the slow queries report provided by our monitoring tool.

I verified this by running the query on 4 000 rows and 400 000 rows and the difference was about 100x slower on the latter. After adding the index, the query was about 100x faster than in the former, so it would make sense to have the index even on smaller amounts of users.

I have only tested on hsql and mysql, for the others I just copied the syntax from similar operations. 
I used the length 105 for mysql because in our database all the refresh tokens are of that length.