### PR TITLE
Fetch tokens by user name

### DIFF
--- a/openid-connect-common/src/main/java/org/mitre/oauth2/model/OAuth2AccessTokenEntity.java
+++ b/openid-connect-common/src/main/java/org/mitre/oauth2/model/OAuth2AccessTokenEntity.java
@@ -71,7 +71,8 @@ import com.nimbusds.jwt.JWT;
 	@NamedQuery(name = OAuth2AccessTokenEntity.QUERY_BY_CLIENT, query = "select a from OAuth2AccessTokenEntity a where a.client = :" + OAuth2AccessTokenEntity.PARAM_CLIENT),
 	@NamedQuery(name = OAuth2AccessTokenEntity.QUERY_BY_TOKEN_VALUE, query = "select a from OAuth2AccessTokenEntity a where a.jwt = :" + OAuth2AccessTokenEntity.PARAM_TOKEN_VALUE),
 	@NamedQuery(name = OAuth2AccessTokenEntity.QUERY_BY_APPROVED_SITE, query = "select a from OAuth2AccessTokenEntity a where a.approvedSite = :" + OAuth2AccessTokenEntity.PARAM_APPROVED_SITE),
-	@NamedQuery(name = OAuth2AccessTokenEntity.QUERY_BY_RESOURCE_SET, query = "select a from OAuth2AccessTokenEntity a join a.permissions p where p.resourceSet.id = :" + OAuth2AccessTokenEntity.PARAM_RESOURCE_SET_ID)
+	@NamedQuery(name = OAuth2AccessTokenEntity.QUERY_BY_RESOURCE_SET, query = "select a from OAuth2AccessTokenEntity a join a.permissions p where p.resourceSet.id = :" + OAuth2AccessTokenEntity.PARAM_RESOURCE_SET_ID),
+	@NamedQuery(name = OAuth2AccessTokenEntity.QUERY_BY_SUB, query = "select r from OAuth2AccessTokenEntity r where r.authenticationHolder.userAuth.name = :" + OAuth2AccessTokenEntity.PARAM_SUB)
 })
 @org.codehaus.jackson.map.annotate.JsonSerialize(using = OAuth2AccessTokenJackson1Serializer.class)
 @org.codehaus.jackson.map.annotate.JsonDeserialize(using = OAuth2AccessTokenJackson1Deserializer.class)
@@ -86,6 +87,7 @@ public class OAuth2AccessTokenEntity implements OAuth2AccessToken {
 	public static final String QUERY_EXPIRED_BY_DATE = "OAuth2AccessTokenEntity.getAllExpiredByDate";
 	public static final String QUERY_ALL = "OAuth2AccessTokenEntity.getAll";
 	public static final String QUERY_BY_RESOURCE_SET = "OAuth2AccessTokenEntity.getByResourceSet";
+	public static final String QUERY_BY_SUB = "OAuth2AccessTokenEntity.getBySub";
 
 	public static final String PARAM_TOKEN_VALUE = "tokenValue";
 	public static final String PARAM_CLIENT = "client";
@@ -93,6 +95,7 @@ public class OAuth2AccessTokenEntity implements OAuth2AccessToken {
 	public static final String PARAM_DATE = "date";
 	public static final String PARAM_RESOURCE_SET_ID = "rsid";
 	public static final String PARAM_APPROVED_SITE = "approvedSite";
+	public static final String PARAM_SUB = "sub";
 
 	public static final String ID_TOKEN_FIELD_NAME = "id_token";
 

--- a/openid-connect-common/src/main/java/org/mitre/oauth2/model/OAuth2AccessTokenEntity.java
+++ b/openid-connect-common/src/main/java/org/mitre/oauth2/model/OAuth2AccessTokenEntity.java
@@ -72,7 +72,7 @@ import com.nimbusds.jwt.JWT;
 	@NamedQuery(name = OAuth2AccessTokenEntity.QUERY_BY_TOKEN_VALUE, query = "select a from OAuth2AccessTokenEntity a where a.jwt = :" + OAuth2AccessTokenEntity.PARAM_TOKEN_VALUE),
 	@NamedQuery(name = OAuth2AccessTokenEntity.QUERY_BY_APPROVED_SITE, query = "select a from OAuth2AccessTokenEntity a where a.approvedSite = :" + OAuth2AccessTokenEntity.PARAM_APPROVED_SITE),
 	@NamedQuery(name = OAuth2AccessTokenEntity.QUERY_BY_RESOURCE_SET, query = "select a from OAuth2AccessTokenEntity a join a.permissions p where p.resourceSet.id = :" + OAuth2AccessTokenEntity.PARAM_RESOURCE_SET_ID),
-	@NamedQuery(name = OAuth2AccessTokenEntity.QUERY_BY_SUB, query = "select r from OAuth2AccessTokenEntity r where r.authenticationHolder.userAuth.name = :" + OAuth2AccessTokenEntity.PARAM_SUB)
+	@NamedQuery(name = OAuth2AccessTokenEntity.QUERY_BY_NAME, query = "select r from OAuth2AccessTokenEntity r where r.authenticationHolder.userAuth.name = :" + OAuth2AccessTokenEntity.PARAM_NAME)
 })
 @org.codehaus.jackson.map.annotate.JsonSerialize(using = OAuth2AccessTokenJackson1Serializer.class)
 @org.codehaus.jackson.map.annotate.JsonDeserialize(using = OAuth2AccessTokenJackson1Deserializer.class)
@@ -87,7 +87,7 @@ public class OAuth2AccessTokenEntity implements OAuth2AccessToken {
 	public static final String QUERY_EXPIRED_BY_DATE = "OAuth2AccessTokenEntity.getAllExpiredByDate";
 	public static final String QUERY_ALL = "OAuth2AccessTokenEntity.getAll";
 	public static final String QUERY_BY_RESOURCE_SET = "OAuth2AccessTokenEntity.getByResourceSet";
-	public static final String QUERY_BY_SUB = "OAuth2AccessTokenEntity.getBySub";
+	public static final String QUERY_BY_NAME = "OAuth2AccessTokenEntity.getByName";
 
 	public static final String PARAM_TOKEN_VALUE = "tokenValue";
 	public static final String PARAM_CLIENT = "client";
@@ -95,7 +95,7 @@ public class OAuth2AccessTokenEntity implements OAuth2AccessToken {
 	public static final String PARAM_DATE = "date";
 	public static final String PARAM_RESOURCE_SET_ID = "rsid";
 	public static final String PARAM_APPROVED_SITE = "approvedSite";
-	public static final String PARAM_SUB = "sub";
+	public static final String PARAM_NAME = "name";
 
 	public static final String ID_TOKEN_FIELD_NAME = "id_token";
 

--- a/openid-connect-common/src/main/java/org/mitre/oauth2/model/OAuth2RefreshTokenEntity.java
+++ b/openid-connect-common/src/main/java/org/mitre/oauth2/model/OAuth2RefreshTokenEntity.java
@@ -54,7 +54,7 @@ import com.nimbusds.jwt.JWT;
 	@NamedQuery(name = OAuth2RefreshTokenEntity.QUERY_EXPIRED_BY_DATE, query = "select r from OAuth2RefreshTokenEntity r where r.expiration <= :" + OAuth2RefreshTokenEntity.PARAM_DATE),
 	@NamedQuery(name = OAuth2RefreshTokenEntity.QUERY_BY_CLIENT, query = "select r from OAuth2RefreshTokenEntity r where r.client = :" + OAuth2RefreshTokenEntity.PARAM_CLIENT),
 	@NamedQuery(name = OAuth2RefreshTokenEntity.QUERY_BY_TOKEN_VALUE, query = "select r from OAuth2RefreshTokenEntity r where r.jwt = :" + OAuth2RefreshTokenEntity.PARAM_TOKEN_VALUE),
-	@NamedQuery(name = OAuth2RefreshTokenEntity.QUERY_BY_SUB, query = "select r from OAuth2RefreshTokenEntity r where r.authenticationHolder.userAuth.name = :" + OAuth2RefreshTokenEntity.PARAM_SUB)
+	@NamedQuery(name = OAuth2RefreshTokenEntity.QUERY_BY_NAME, query = "select r from OAuth2RefreshTokenEntity r where r.authenticationHolder.userAuth.name = :" + OAuth2RefreshTokenEntity.PARAM_NAME)
 })
 public class OAuth2RefreshTokenEntity implements OAuth2RefreshToken {
 
@@ -62,12 +62,12 @@ public class OAuth2RefreshTokenEntity implements OAuth2RefreshToken {
 	public static final String QUERY_BY_CLIENT = "OAuth2RefreshTokenEntity.getByClient";
 	public static final String QUERY_EXPIRED_BY_DATE = "OAuth2RefreshTokenEntity.getAllExpiredByDate";
 	public static final String QUERY_ALL = "OAuth2RefreshTokenEntity.getAll";
-	public static final String QUERY_BY_SUB = "OAuth2RefreshTokenEntity.getBySub";
+	public static final String QUERY_BY_NAME = "OAuth2RefreshTokenEntity.getByName";
 
 	public static final String PARAM_TOKEN_VALUE = "tokenValue";
 	public static final String PARAM_CLIENT = "client";
 	public static final String PARAM_DATE = "date";
-	public static final String PARAM_SUB = "sub";
+	public static final String PARAM_NAME = "name";
 
 	private Long id;
 

--- a/openid-connect-common/src/main/java/org/mitre/oauth2/model/OAuth2RefreshTokenEntity.java
+++ b/openid-connect-common/src/main/java/org/mitre/oauth2/model/OAuth2RefreshTokenEntity.java
@@ -53,7 +53,8 @@ import com.nimbusds.jwt.JWT;
 	@NamedQuery(name = OAuth2RefreshTokenEntity.QUERY_ALL, query = "select r from OAuth2RefreshTokenEntity r"),
 	@NamedQuery(name = OAuth2RefreshTokenEntity.QUERY_EXPIRED_BY_DATE, query = "select r from OAuth2RefreshTokenEntity r where r.expiration <= :" + OAuth2RefreshTokenEntity.PARAM_DATE),
 	@NamedQuery(name = OAuth2RefreshTokenEntity.QUERY_BY_CLIENT, query = "select r from OAuth2RefreshTokenEntity r where r.client = :" + OAuth2RefreshTokenEntity.PARAM_CLIENT),
-	@NamedQuery(name = OAuth2RefreshTokenEntity.QUERY_BY_TOKEN_VALUE, query = "select r from OAuth2RefreshTokenEntity r where r.jwt = :" + OAuth2RefreshTokenEntity.PARAM_TOKEN_VALUE)
+	@NamedQuery(name = OAuth2RefreshTokenEntity.QUERY_BY_TOKEN_VALUE, query = "select r from OAuth2RefreshTokenEntity r where r.jwt = :" + OAuth2RefreshTokenEntity.PARAM_TOKEN_VALUE),
+	@NamedQuery(name = OAuth2RefreshTokenEntity.QUERY_BY_SUB, query = "select r from OAuth2RefreshTokenEntity r where r.authenticationHolder.userAuth.name = :" + OAuth2RefreshTokenEntity.PARAM_SUB)
 })
 public class OAuth2RefreshTokenEntity implements OAuth2RefreshToken {
 
@@ -61,10 +62,12 @@ public class OAuth2RefreshTokenEntity implements OAuth2RefreshToken {
 	public static final String QUERY_BY_CLIENT = "OAuth2RefreshTokenEntity.getByClient";
 	public static final String QUERY_EXPIRED_BY_DATE = "OAuth2RefreshTokenEntity.getAllExpiredByDate";
 	public static final String QUERY_ALL = "OAuth2RefreshTokenEntity.getAll";
+	public static final String QUERY_BY_SUB = "OAuth2RefreshTokenEntity.getBySub";
 
 	public static final String PARAM_TOKEN_VALUE = "tokenValue";
 	public static final String PARAM_CLIENT = "client";
 	public static final String PARAM_DATE = "date";
+	public static final String PARAM_SUB = "sub";
 
 	private Long id;
 

--- a/openid-connect-common/src/main/java/org/mitre/oauth2/repository/OAuth2TokenRepository.java
+++ b/openid-connect-common/src/main/java/org/mitre/oauth2/repository/OAuth2TokenRepository.java
@@ -53,9 +53,9 @@ public interface OAuth2TokenRepository {
 
 	public List<OAuth2RefreshTokenEntity> getRefreshTokensForClient(ClientDetailsEntity client);
 	
-	public Set<OAuth2AccessTokenEntity> getAccessTokensBySub(String sub);
+	public Set<OAuth2AccessTokenEntity> getAccessTokensByUserName(String name);
 	
-	public Set<OAuth2RefreshTokenEntity> getRefreshTokensBySub(String sub);
+	public Set<OAuth2RefreshTokenEntity> getRefreshTokensByUserName(String name);
 
 	public Set<OAuth2AccessTokenEntity> getAllAccessTokens();
 

--- a/openid-connect-common/src/main/java/org/mitre/oauth2/repository/OAuth2TokenRepository.java
+++ b/openid-connect-common/src/main/java/org/mitre/oauth2/repository/OAuth2TokenRepository.java
@@ -52,6 +52,10 @@ public interface OAuth2TokenRepository {
 	public List<OAuth2AccessTokenEntity> getAccessTokensForClient(ClientDetailsEntity client);
 
 	public List<OAuth2RefreshTokenEntity> getRefreshTokensForClient(ClientDetailsEntity client);
+	
+	public Set<OAuth2AccessTokenEntity> getAccessTokensBySub(String sub);
+	
+	public Set<OAuth2RefreshTokenEntity> getRefreshTokensBySub(String sub);
 
 	public Set<OAuth2AccessTokenEntity> getAllAccessTokens();
 

--- a/openid-connect-server/src/main/java/org/mitre/oauth2/repository/impl/JpaOAuth2TokenRepository.java
+++ b/openid-connect-server/src/main/java/org/mitre/oauth2/repository/impl/JpaOAuth2TokenRepository.java
@@ -20,6 +20,7 @@ package org.mitre.oauth2.repository.impl;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -188,6 +189,22 @@ public class JpaOAuth2TokenRepository implements OAuth2TokenRepository {
 		queryR.setParameter(OAuth2RefreshTokenEntity.PARAM_CLIENT, client);
 		List<OAuth2RefreshTokenEntity> refreshTokens = queryR.getResultList();
 		return refreshTokens;
+	}
+	
+	@Override
+	public Set<OAuth2AccessTokenEntity> getAccessTokensBySub(String sub) {
+		TypedQuery<OAuth2AccessTokenEntity> query = manager.createNamedQuery(OAuth2AccessTokenEntity.QUERY_BY_SUB, OAuth2AccessTokenEntity.class);
+	    query.setParameter(OAuth2AccessTokenEntity.PARAM_SUB, sub);
+	    List<OAuth2AccessTokenEntity> results = query.getResultList();
+	    return results != null ? new HashSet<>(query.getResultList()) : new HashSet<>();
+	}
+	
+	@Override
+	public Set<OAuth2RefreshTokenEntity> getRefreshTokensBySub(String sub) {
+		TypedQuery<OAuth2RefreshTokenEntity> query = manager.createNamedQuery(OAuth2RefreshTokenEntity.QUERY_BY_SUB, OAuth2RefreshTokenEntity.class);
+	    query.setParameter(OAuth2RefreshTokenEntity.PARAM_SUB, sub);
+	    List<OAuth2RefreshTokenEntity> results = query.getResultList();
+	    return results != null ? new HashSet<>(query.getResultList()) : new HashSet<>();
 	}
 
 	@Override

--- a/openid-connect-server/src/main/java/org/mitre/oauth2/repository/impl/JpaOAuth2TokenRepository.java
+++ b/openid-connect-server/src/main/java/org/mitre/oauth2/repository/impl/JpaOAuth2TokenRepository.java
@@ -186,17 +186,17 @@ public class JpaOAuth2TokenRepository implements OAuth2TokenRepository {
 	}
 	
 	@Override
-	public Set<OAuth2AccessTokenEntity> getAccessTokensBySub(String sub) {
-		TypedQuery<OAuth2AccessTokenEntity> query = manager.createNamedQuery(OAuth2AccessTokenEntity.QUERY_BY_SUB, OAuth2AccessTokenEntity.class);
-	    query.setParameter(OAuth2AccessTokenEntity.PARAM_SUB, sub);
+	public Set<OAuth2AccessTokenEntity> getAccessTokensByUserName(String name) {
+		TypedQuery<OAuth2AccessTokenEntity> query = manager.createNamedQuery(OAuth2AccessTokenEntity.QUERY_BY_NAME, OAuth2AccessTokenEntity.class);
+	    query.setParameter(OAuth2AccessTokenEntity.PARAM_NAME, name);
 	    List<OAuth2AccessTokenEntity> results = query.getResultList();
 	    return results != null ? new HashSet<>(query.getResultList()) : new HashSet<>();
 	}
 	
 	@Override
-	public Set<OAuth2RefreshTokenEntity> getRefreshTokensBySub(String sub) {
-		TypedQuery<OAuth2RefreshTokenEntity> query = manager.createNamedQuery(OAuth2RefreshTokenEntity.QUERY_BY_SUB, OAuth2RefreshTokenEntity.class);
-	    query.setParameter(OAuth2RefreshTokenEntity.PARAM_SUB, sub);
+	public Set<OAuth2RefreshTokenEntity> getRefreshTokensByUserName(String name) {
+		TypedQuery<OAuth2RefreshTokenEntity> query = manager.createNamedQuery(OAuth2RefreshTokenEntity.QUERY_BY_NAME, OAuth2RefreshTokenEntity.class);
+	    query.setParameter(OAuth2RefreshTokenEntity.PARAM_NAME, name);
 	    List<OAuth2RefreshTokenEntity> results = query.getResultList();
 	    return results != null ? new HashSet<>(query.getResultList()) : new HashSet<>();
 	}

--- a/openid-connect-server/src/main/java/org/mitre/oauth2/repository/impl/JpaOAuth2TokenRepository.java
+++ b/openid-connect-server/src/main/java/org/mitre/oauth2/repository/impl/JpaOAuth2TokenRepository.java
@@ -169,9 +169,6 @@ public class JpaOAuth2TokenRepository implements OAuth2TokenRepository {
 		}
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mitre.oauth2.repository.OAuth2TokenRepository#getAccessTokensForClient(org.mitre.oauth2.model.ClientDetailsEntity)
-	 */
 	@Override
 	public List<OAuth2AccessTokenEntity> getAccessTokensForClient(ClientDetailsEntity client) {
 		TypedQuery<OAuth2AccessTokenEntity> queryA = manager.createNamedQuery(OAuth2AccessTokenEntity.QUERY_BY_CLIENT, OAuth2AccessTokenEntity.class);
@@ -180,9 +177,6 @@ public class JpaOAuth2TokenRepository implements OAuth2TokenRepository {
 		return accessTokens;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mitre.oauth2.repository.OAuth2TokenRepository#getRefreshTokensForClient(org.mitre.oauth2.model.ClientDetailsEntity)
-	 */
 	@Override
 	public List<OAuth2RefreshTokenEntity> getRefreshTokensForClient(ClientDetailsEntity client) {
 		TypedQuery<OAuth2RefreshTokenEntity> queryR = manager.createNamedQuery(OAuth2RefreshTokenEntity.QUERY_BY_CLIENT, OAuth2RefreshTokenEntity.class);
@@ -233,11 +227,6 @@ public class JpaOAuth2TokenRepository implements OAuth2TokenRepository {
 		return new LinkedHashSet<>(JpaUtil.getResultPage(query,pageCriteria));
 	}
 
-
-
-	/* (non-Javadoc)
-	 * @see org.mitre.oauth2.repository.OAuth2TokenRepository#getAccessTokensForResourceSet(org.mitre.uma.model.ResourceSet)
-	 */
 	@Override
 	public Set<OAuth2AccessTokenEntity> getAccessTokensForResourceSet(ResourceSet rs) {
 		TypedQuery<OAuth2AccessTokenEntity> query = manager.createNamedQuery(OAuth2AccessTokenEntity.QUERY_BY_RESOURCE_SET, OAuth2AccessTokenEntity.class);
@@ -245,13 +234,9 @@ public class JpaOAuth2TokenRepository implements OAuth2TokenRepository {
 		return new LinkedHashSet<>(query.getResultList());
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mitre.oauth2.repository.OAuth2TokenRepository#clearDuplicateAccessTokens()
-	 */
 	@Override
 	@Transactional(value="defaultTransactionManager")
 	public void clearDuplicateAccessTokens() {
-
 		Query query = manager.createQuery("select a.jwt, count(1) as c from OAuth2AccessTokenEntity a GROUP BY a.jwt HAVING count(1) > 1");
 		@SuppressWarnings("unchecked")
 		List<Object[]> resultList = query.getResultList();
@@ -270,9 +255,6 @@ public class JpaOAuth2TokenRepository implements OAuth2TokenRepository {
 		}
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mitre.oauth2.repository.OAuth2TokenRepository#clearDuplicateRefreshTokens()
-	 */
 	@Override
 	@Transactional(value="defaultTransactionManager")
 	public void clearDuplicateRefreshTokens() {

--- a/openid-connect-server/src/main/java/org/mitre/oauth2/service/impl/DefaultOAuth2ProviderTokenService.java
+++ b/openid-connect-server/src/main/java/org/mitre/oauth2/service/impl/DefaultOAuth2ProviderTokenService.java
@@ -66,7 +66,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.google.common.base.Strings;
-import com.google.common.collect.Sets;
 import com.nimbusds.jose.util.Base64URL;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.PlainJWT;
@@ -102,35 +101,14 @@ public class DefaultOAuth2ProviderTokenService implements OAuth2TokenEntityServi
 	@Autowired
 	private ApprovedSiteService approvedSiteService;
 
-
 	@Override
-	public Set<OAuth2AccessTokenEntity> getAllAccessTokensForUser(String id) {
-
-		Set<OAuth2AccessTokenEntity> all = tokenRepository.getAllAccessTokens();
-		Set<OAuth2AccessTokenEntity> results = Sets.newLinkedHashSet();
-
-		for (OAuth2AccessTokenEntity token : all) {
-			if (clearExpiredAccessToken(token) != null && token.getAuthenticationHolder().getAuthentication().getName().equals(id)) {
-				results.add(token);
-			}
-		}
-
-		return results;
+	public Set<OAuth2AccessTokenEntity> getAllAccessTokensForUser(String sub) {
+		return tokenRepository.getAccessTokensBySub(sub);
 	}
 
-
 	@Override
-	public Set<OAuth2RefreshTokenEntity> getAllRefreshTokensForUser(String id) {
-		Set<OAuth2RefreshTokenEntity> all = tokenRepository.getAllRefreshTokens();
-		Set<OAuth2RefreshTokenEntity> results = Sets.newLinkedHashSet();
-
-		for (OAuth2RefreshTokenEntity token : all) {
-			if (clearExpiredRefreshToken(token) != null && token.getAuthenticationHolder().getAuthentication().getName().equals(id)) {
-				results.add(token);
-			}
-		}
-
-		return results;
+	public Set<OAuth2RefreshTokenEntity> getAllRefreshTokensForUser(String sub) {
+		return tokenRepository.getRefreshTokensBySub(sub);
 	}
 
 	@Override

--- a/openid-connect-server/src/main/java/org/mitre/oauth2/service/impl/DefaultOAuth2ProviderTokenService.java
+++ b/openid-connect-server/src/main/java/org/mitre/oauth2/service/impl/DefaultOAuth2ProviderTokenService.java
@@ -170,7 +170,6 @@ public class DefaultOAuth2ProviderTokenService implements OAuth2TokenEntityServi
 				throw new InvalidClientException("Client not found: " + request.getClientId());
 			}
 
-
 			// handle the PKCE code challenge if present
 			if (request.getExtensions().containsKey(CODE_CHALLENGE)) {
 				String challenge = (String) request.getExtensions().get(CODE_CHALLENGE);
@@ -197,7 +196,6 @@ public class DefaultOAuth2ProviderTokenService implements OAuth2TokenEntityServi
 				}
 
 			}
-
 
 			OAuth2AccessTokenEntity token = new OAuth2AccessTokenEntity();//accessTokenFactory.createNewAccessToken();
 
@@ -283,8 +281,6 @@ public class DefaultOAuth2ProviderTokenService implements OAuth2TokenEntityServi
 		//Add the authentication
 		refreshToken.setAuthenticationHolder(authHolder);
 		refreshToken.setClient(client);
-
-
 
 		// save the token first so that we can set it to a member of the access token (NOTE: is this step necessary?)
 		OAuth2RefreshTokenEntity savedRefreshToken = tokenRepository.saveRefreshToken(refreshToken);
@@ -388,12 +384,10 @@ public class DefaultOAuth2ProviderTokenService implements OAuth2TokenEntityServi
 		tokenRepository.saveAccessToken(token);
 
 		return token;
-
 	}
 
 	@Override
 	public OAuth2Authentication loadAuthentication(String accessTokenValue) throws AuthenticationException {
-
 		OAuth2AccessTokenEntity accessToken = clearExpiredAccessToken(tokenRepository.getAccessTokenByValue(accessTokenValue));
 
 		if (accessToken == null) {
@@ -459,18 +453,11 @@ public class DefaultOAuth2ProviderTokenService implements OAuth2TokenEntityServi
 		tokenRepository.removeAccessToken(accessToken);
 	}
 
-
-	/* (non-Javadoc)
-	 * @see org.mitre.oauth2.service.OAuth2TokenEntityService#getAccessTokensForClient(org.mitre.oauth2.model.ClientDetailsEntity)
-	 */
 	@Override
 	public List<OAuth2AccessTokenEntity> getAccessTokensForClient(ClientDetailsEntity client) {
 		return tokenRepository.getAccessTokensForClient(client);
 	}
 
-	/* (non-Javadoc)
-	 * @see org.mitre.oauth2.service.OAuth2TokenEntityService#getRefreshTokensForClient(org.mitre.oauth2.model.ClientDetailsEntity)
-	 */
 	@Override
 	public List<OAuth2RefreshTokenEntity> getRefreshTokensForClient(ClientDetailsEntity client) {
 		return tokenRepository.getRefreshTokensForClient(client);
@@ -573,7 +560,4 @@ public class DefaultOAuth2ProviderTokenService implements OAuth2TokenEntityServi
 
 		return null;
 	}
-
-
-
 }

--- a/openid-connect-server/src/main/java/org/mitre/oauth2/service/impl/DefaultOAuth2ProviderTokenService.java
+++ b/openid-connect-server/src/main/java/org/mitre/oauth2/service/impl/DefaultOAuth2ProviderTokenService.java
@@ -102,13 +102,13 @@ public class DefaultOAuth2ProviderTokenService implements OAuth2TokenEntityServi
 	private ApprovedSiteService approvedSiteService;
 
 	@Override
-	public Set<OAuth2AccessTokenEntity> getAllAccessTokensForUser(String sub) {
-		return tokenRepository.getAccessTokensBySub(sub);
+	public Set<OAuth2AccessTokenEntity> getAllAccessTokensForUser(String userName) {
+		return tokenRepository.getAccessTokensByUserName(userName);
 	}
 
 	@Override
-	public Set<OAuth2RefreshTokenEntity> getAllRefreshTokensForUser(String sub) {
-		return tokenRepository.getRefreshTokensBySub(sub);
+	public Set<OAuth2RefreshTokenEntity> getAllRefreshTokensForUser(String userName) {
+		return tokenRepository.getRefreshTokensByUserName(userName);
 	}
 
 	@Override

--- a/openid-connect-server/src/test/java/org/mitre/oauth2/service/impl/TestDefaultOAuth2ProviderTokenService.java
+++ b/openid-connect-server/src/test/java/org/mitre/oauth2/service/impl/TestDefaultOAuth2ProviderTokenService.java
@@ -21,7 +21,6 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -63,7 +62,6 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.when;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -88,7 +86,7 @@ public class TestDefaultOAuth2ProviderTokenService {
 	private OAuth2RefreshTokenEntity refreshToken;
 	private OAuth2AccessTokenEntity accessToken;
 	private String refreshTokenValue = "refresh_token_value";
-	private String userSub = "6a50ac11786d402a9591d3e592ac770f";
+	private String userName = "6a50ac11786d402a9591d3e592ac770f";
 	private TokenRequest tokenRequest;
 
 	// for use when refreshing access tokens
@@ -552,18 +550,18 @@ public class TestDefaultOAuth2ProviderTokenService {
 	
 	@Test
 	public void getAllAccessTokensForUser(){
-		Mockito.when(tokenRepository.getAccessTokensBySub(userSub)).thenReturn(newHashSet(accessToken));
+		Mockito.when(tokenRepository.getAccessTokensByUserName(userName)).thenReturn(newHashSet(accessToken));
 		
-		Set<OAuth2AccessTokenEntity> tokens = service.getAllAccessTokensForUser(userSub);
+		Set<OAuth2AccessTokenEntity> tokens = service.getAllAccessTokensForUser(userName);
 		assertEquals(1, tokens.size());
 		assertTrue(tokens.contains(accessToken));
 	}
 	
 	@Test
 	public void getAllRefreshTokensForUser(){
-		Mockito.when(tokenRepository.getRefreshTokensBySub(userSub)).thenReturn(newHashSet(refreshToken));
+		Mockito.when(tokenRepository.getRefreshTokensByUserName(userName)).thenReturn(newHashSet(refreshToken));
 		
-		Set<OAuth2RefreshTokenEntity> tokens = service.getAllRefreshTokensForUser(userSub);
+		Set<OAuth2RefreshTokenEntity> tokens = service.getAllRefreshTokensForUser(userName);
 		assertEquals(1, tokens.size());
 		assertTrue(tokens.contains(refreshToken));
 	}

--- a/openid-connect-server/src/test/java/org/mitre/oauth2/service/impl/TestDefaultOAuth2ProviderTokenService.java
+++ b/openid-connect-server/src/test/java/org/mitre/oauth2/service/impl/TestDefaultOAuth2ProviderTokenService.java
@@ -33,7 +33,6 @@ import org.mitre.oauth2.repository.AuthenticationHolderRepository;
 import org.mitre.oauth2.repository.OAuth2TokenRepository;
 import org.mitre.oauth2.service.ClientDetailsEntityService;
 import org.mitre.oauth2.service.SystemScopeService;
-import org.mockito.AdditionalAnswers;
 import org.mockito.InjectMocks;
 import org.mockito.Matchers;
 import org.mockito.Mock;
@@ -50,16 +49,21 @@ import org.springframework.security.oauth2.provider.OAuth2Request;
 import org.springframework.security.oauth2.provider.TokenRequest;
 import org.springframework.security.oauth2.provider.token.TokenEnhancer;
 
-import com.google.common.collect.Sets;
-
 import static com.google.common.collect.Sets.newHashSet;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
-
+import static org.mockito.AdditionalAnswers.returnsFirstArg;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anySet;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
@@ -82,7 +86,7 @@ public class TestDefaultOAuth2ProviderTokenService {
 	private ClientDetailsEntity badClient;
 	private String clientId = "test_client";
 	private String badClientId = "bad_client";
-	private Set<String> scope = Sets.newHashSet("openid", "profile", "email", "offline_access");
+	private Set<String> scope = newHashSet("openid", "profile", "email", "offline_access");
 	private OAuth2RefreshTokenEntity refreshToken;
 	private OAuth2AccessTokenEntity accessToken;
 	private String refreshTokenValue = "refresh_token_value";
@@ -118,33 +122,31 @@ public class TestDefaultOAuth2ProviderTokenService {
 	 */
 	@Before
 	public void prepare() {
-		Mockito.reset(tokenRepository, authenticationHolderRepository, clientDetailsService, tokenEnhancer);
-
-
+		reset(tokenRepository, authenticationHolderRepository, clientDetailsService, tokenEnhancer);
 
 		authentication = Mockito.mock(OAuth2Authentication.class);
 		OAuth2Request clientAuth = new OAuth2Request(null, clientId, null, true, scope, null, null, null, null);
-		Mockito.when(authentication.getOAuth2Request()).thenReturn(clientAuth);
+		when(authentication.getOAuth2Request()).thenReturn(clientAuth);
 
 		client = Mockito.mock(ClientDetailsEntity.class);
-		Mockito.when(client.getClientId()).thenReturn(clientId);
-		Mockito.when(clientDetailsService.loadClientByClientId(clientId)).thenReturn(client);
-		Mockito.when(client.isReuseRefreshToken()).thenReturn(true);
+		when(client.getClientId()).thenReturn(clientId);
+		when(clientDetailsService.loadClientByClientId(clientId)).thenReturn(client);
+		when(client.isReuseRefreshToken()).thenReturn(true);
 
 		// by default in tests, allow refresh tokens
-		Mockito.when(client.isAllowRefresh()).thenReturn(true);
+		when(client.isAllowRefresh()).thenReturn(true);
 
 		// by default, clear access tokens on refresh
-		Mockito.when(client.isClearAccessTokensOnRefresh()).thenReturn(true);
+		when(client.isClearAccessTokensOnRefresh()).thenReturn(true);
 
 		badClient = Mockito.mock(ClientDetailsEntity.class);
-		Mockito.when(badClient.getClientId()).thenReturn(badClientId);
-		Mockito.when(clientDetailsService.loadClientByClientId(badClientId)).thenReturn(badClient);
+		when(badClient.getClientId()).thenReturn(badClientId);
+		when(clientDetailsService.loadClientByClientId(badClientId)).thenReturn(badClient);
 
 		refreshToken = Mockito.mock(OAuth2RefreshTokenEntity.class);
-		Mockito.when(tokenRepository.getRefreshTokenByValue(refreshTokenValue)).thenReturn(refreshToken);
-		Mockito.when(refreshToken.getClient()).thenReturn(client);
-		Mockito.when(refreshToken.isExpired()).thenReturn(false);
+		when(tokenRepository.getRefreshTokenByValue(refreshTokenValue)).thenReturn(refreshToken);
+		when(refreshToken.getClient()).thenReturn(client);
+		when(refreshToken.isExpired()).thenReturn(false);
 		
 		accessToken = Mockito.mock(OAuth2AccessTokenEntity.class);
 
@@ -152,16 +154,16 @@ public class TestDefaultOAuth2ProviderTokenService {
 
 		storedAuthentication = authentication;
 		storedAuthRequest = clientAuth;
-		storedAuthHolder = Mockito.mock(AuthenticationHolderEntity.class);
-		storedScope = Sets.newHashSet(scope);
+		storedAuthHolder = mock(AuthenticationHolderEntity.class);
+		storedScope = newHashSet(scope);
 
-		Mockito.when(refreshToken.getAuthenticationHolder()).thenReturn(storedAuthHolder);
-		Mockito.when(storedAuthHolder.getAuthentication()).thenReturn(storedAuthentication);
-		Mockito.when(storedAuthentication.getOAuth2Request()).thenReturn(storedAuthRequest);
+		when(refreshToken.getAuthenticationHolder()).thenReturn(storedAuthHolder);
+		when(storedAuthHolder.getAuthentication()).thenReturn(storedAuthentication);
+		when(storedAuthentication.getOAuth2Request()).thenReturn(storedAuthRequest);
 
-		Mockito.when(authenticationHolderRepository.save(Matchers.any(AuthenticationHolderEntity.class))).thenReturn(storedAuthHolder);
+		when(authenticationHolderRepository.save(any(AuthenticationHolderEntity.class))).thenReturn(storedAuthHolder);
 
-		Mockito.when(scopeService.fromStrings(Matchers.anySet())).thenAnswer(new Answer<Set<SystemScope>>() {
+		when(scopeService.fromStrings(anySet())).thenAnswer(new Answer<Set<SystemScope>>() {
 			@Override
 			public Set<SystemScope> answer(InvocationOnMock invocation) throws Throwable {
 				Object[] args = invocation.getArguments();
@@ -174,7 +176,7 @@ public class TestDefaultOAuth2ProviderTokenService {
 			}
 		});
 
-		Mockito.when(scopeService.toStrings(Matchers.anySet())).thenAnswer(new Answer<Set<String>>() {
+		when(scopeService.toStrings(anySet())).thenAnswer(new Answer<Set<String>>() {
 			@Override
 			public Set<String> answer(InvocationOnMock invocation) throws Throwable {
 				Object[] args = invocation.getArguments();
@@ -188,10 +190,10 @@ public class TestDefaultOAuth2ProviderTokenService {
 		});
 
 		// we're not testing restricted or reserved scopes here, just pass through
-		Mockito.when(scopeService.removeReservedScopes(Matchers.anySet())).then(AdditionalAnswers.returnsFirstArg());
-		Mockito.when(scopeService.removeRestrictedAndReservedScopes(Matchers.anySet())).then(AdditionalAnswers.returnsFirstArg());
+		when(scopeService.removeReservedScopes(anySet())).then(returnsFirstArg());
+		when(scopeService.removeRestrictedAndReservedScopes(anySet())).then(returnsFirstArg());
 
-		Mockito.when(tokenEnhancer.enhance(Matchers.any(OAuth2AccessTokenEntity.class), Matchers.any(OAuth2Authentication.class)))
+		when(tokenEnhancer.enhance(any(OAuth2AccessTokenEntity.class), any(OAuth2Authentication.class)))
 		.thenAnswer(new Answer<OAuth2AccessTokenEntity>(){
 			@Override
 			public OAuth2AccessTokenEntity answer(InvocationOnMock invocation) throws Throwable {
@@ -200,7 +202,7 @@ public class TestDefaultOAuth2ProviderTokenService {
 			}
 		});
 
-		Mockito.when(tokenRepository.saveAccessToken(Matchers.any(OAuth2AccessTokenEntity.class)))
+		when(tokenRepository.saveAccessToken(any(OAuth2AccessTokenEntity.class)))
 		.thenAnswer(new Answer<OAuth2AccessTokenEntity>() {
 			@Override
 			public OAuth2AccessTokenEntity answer(InvocationOnMock invocation) throws Throwable {
@@ -210,7 +212,7 @@ public class TestDefaultOAuth2ProviderTokenService {
 
 		});
 
-		Mockito.when(tokenRepository.saveRefreshToken(Matchers.any(OAuth2RefreshTokenEntity.class)))
+		when(tokenRepository.saveRefreshToken(any(OAuth2RefreshTokenEntity.class)))
 		.thenAnswer(new Answer<OAuth2RefreshTokenEntity>() {
 			@Override
 			public OAuth2RefreshTokenEntity answer(InvocationOnMock invocation) throws Throwable {
@@ -226,8 +228,7 @@ public class TestDefaultOAuth2ProviderTokenService {
 	 */
 	@Test
 	public void createAccessToken_nullAuth() {
-
-		Mockito.when(authentication.getOAuth2Request()).thenReturn(null);
+		when(authentication.getOAuth2Request()).thenReturn(null);
 
 		try {
 			service.createAccessToken(null);
@@ -249,8 +250,7 @@ public class TestDefaultOAuth2ProviderTokenService {
 	 */
 	@Test(expected = InvalidClientException.class)
 	public void createAccessToken_nullClient() {
-
-		Mockito.when(clientDetailsService.loadClientByClientId(Matchers.anyString())).thenReturn(null);
+		when(clientDetailsService.loadClientByClientId(anyString())).thenReturn(null);
 
 		service.createAccessToken(authentication);
 	}
@@ -260,18 +260,17 @@ public class TestDefaultOAuth2ProviderTokenService {
 	 */
 	@Test
 	public void createAccessToken_noRefresh() {
-
-		Mockito.when(client.isAllowRefresh()).thenReturn(false);
+		when(client.isAllowRefresh()).thenReturn(false);
 
 		OAuth2AccessTokenEntity token = service.createAccessToken(authentication);
 
-		Mockito.verify(clientDetailsService).loadClientByClientId(Matchers.anyString());
-		Mockito.verify(authenticationHolderRepository).save(Matchers.any(AuthenticationHolderEntity.class));
-		Mockito.verify(tokenEnhancer).enhance(Matchers.any(OAuth2AccessTokenEntity.class), Matchers.eq(authentication));
-		Mockito.verify(tokenRepository).saveAccessToken(Matchers.any(OAuth2AccessTokenEntity.class));
-		Mockito.verify(scopeService, Mockito.atLeastOnce()).removeReservedScopes(Matchers.anySet());
+		verify(clientDetailsService).loadClientByClientId(anyString());
+		verify(authenticationHolderRepository).save(any(AuthenticationHolderEntity.class));
+		verify(tokenEnhancer).enhance(any(OAuth2AccessTokenEntity.class), Matchers.eq(authentication));
+		verify(tokenRepository).saveAccessToken(any(OAuth2AccessTokenEntity.class));
+		verify(scopeService, atLeastOnce()).removeReservedScopes(anySet());
 
-		Mockito.verify(tokenRepository, Mockito.never()).saveRefreshToken(Matchers.any(OAuth2RefreshTokenEntity.class));
+		verify(tokenRepository, Mockito.never()).saveRefreshToken(any(OAuth2RefreshTokenEntity.class));
 
 		assertThat(token.getRefreshToken(), is(nullValue()));
 	}
@@ -281,19 +280,17 @@ public class TestDefaultOAuth2ProviderTokenService {
 	 */
 	@Test
 	public void createAccessToken_yesRefresh() {
-
-		OAuth2Request clientAuth = new OAuth2Request(null, clientId, null, true, Sets.newHashSet(SystemScopeService.OFFLINE_ACCESS), null, null, null, null);
-		Mockito.when(authentication.getOAuth2Request()).thenReturn(clientAuth);
-		Mockito.when(client.isAllowRefresh()).thenReturn(true);
+		OAuth2Request clientAuth = new OAuth2Request(null, clientId, null, true, newHashSet(SystemScopeService.OFFLINE_ACCESS), null, null, null, null);
+		when(authentication.getOAuth2Request()).thenReturn(clientAuth);
+		when(client.isAllowRefresh()).thenReturn(true);
 
 		OAuth2AccessTokenEntity token = service.createAccessToken(authentication);
 
 		// Note: a refactor may be appropriate to only save refresh tokens once to the repository during creation.
-		Mockito.verify(tokenRepository, Mockito.atLeastOnce()).saveRefreshToken(Matchers.any(OAuth2RefreshTokenEntity.class));
-		Mockito.verify(scopeService, Mockito.atLeastOnce()).removeReservedScopes(Matchers.anySet());
+		verify(tokenRepository, atLeastOnce()).saveRefreshToken(any(OAuth2RefreshTokenEntity.class));
+		verify(scopeService, atLeastOnce()).removeReservedScopes(anySet());
 
 		assertThat(token.getRefreshToken(), is(notNullValue()));
-
 	}
 
 	/**
@@ -301,12 +298,11 @@ public class TestDefaultOAuth2ProviderTokenService {
 	 */
 	@Test
 	public void createAccessToken_expiration() {
-
 		Integer accessTokenValiditySeconds = 3600;
 		Integer refreshTokenValiditySeconds = 600;
 
-		Mockito.when(client.getAccessTokenValiditySeconds()).thenReturn(accessTokenValiditySeconds);
-		Mockito.when(client.getRefreshTokenValiditySeconds()).thenReturn(refreshTokenValiditySeconds);
+		when(client.getAccessTokenValiditySeconds()).thenReturn(accessTokenValiditySeconds);
+		when(client.getRefreshTokenValiditySeconds()).thenReturn(refreshTokenValiditySeconds);
 
 		long start = System.currentTimeMillis();
 		OAuth2AccessTokenEntity token = service.createAccessToken(authentication);
@@ -318,7 +314,7 @@ public class TestDefaultOAuth2ProviderTokenService {
 		Date lowerBoundRefreshTokens = new Date(start + (refreshTokenValiditySeconds * 1000L) - DELTA);
 		Date upperBoundRefreshTokens = new Date(end + (refreshTokenValiditySeconds * 1000L) + DELTA);
 
-		Mockito.verify(scopeService, Mockito.atLeastOnce()).removeReservedScopes(Matchers.anySet());
+		verify(scopeService, atLeastOnce()).removeReservedScopes(anySet());
 
 		assertTrue(token.getExpiration().after(lowerBoundAccessTokens) && token.getExpiration().before(upperBoundAccessTokens));
 		assertTrue(token.getRefreshToken().getExpiration().after(lowerBoundRefreshTokens) && token.getRefreshToken().getExpiration().before(upperBoundRefreshTokens));
@@ -326,59 +322,52 @@ public class TestDefaultOAuth2ProviderTokenService {
 
 	@Test
 	public void createAccessToken_checkClient() {
-
 		OAuth2AccessTokenEntity token = service.createAccessToken(authentication);
 
-		Mockito.verify(scopeService, Mockito.atLeastOnce()).removeReservedScopes(Matchers.anySet());
+		verify(scopeService, atLeastOnce()).removeReservedScopes(anySet());
 
 		assertThat(token.getClient().getClientId(), equalTo(clientId));
 	}
 
 	@Test
 	public void createAccessToken_checkScopes() {
-
 		OAuth2AccessTokenEntity token = service.createAccessToken(authentication);
 
-		Mockito.verify(scopeService, Mockito.atLeastOnce()).removeReservedScopes(Matchers.anySet());
+		verify(scopeService, atLeastOnce()).removeReservedScopes(anySet());
 
 		assertThat(token.getScope(), equalTo(scope));
 	}
 
 	@Test
 	public void createAccessToken_checkAttachedAuthentication() {
+		AuthenticationHolderEntity authHolder = mock(AuthenticationHolderEntity.class);
+		when(authHolder.getAuthentication()).thenReturn(authentication);
 
-		AuthenticationHolderEntity authHolder = Mockito.mock(AuthenticationHolderEntity.class);
-		Mockito.when(authHolder.getAuthentication()).thenReturn(authentication);
-
-		Mockito.when(authenticationHolderRepository.save(Matchers.any(AuthenticationHolderEntity.class))).thenReturn(authHolder);
+		when(authenticationHolderRepository.save(any(AuthenticationHolderEntity.class))).thenReturn(authHolder);
 
 		OAuth2AccessTokenEntity token = service.createAccessToken(authentication);
 
 		assertThat(token.getAuthenticationHolder().getAuthentication(), equalTo(authentication));
-		Mockito.verify(authenticationHolderRepository).save(Matchers.any(AuthenticationHolderEntity.class));
-		Mockito.verify(scopeService, Mockito.atLeastOnce()).removeReservedScopes(Matchers.anySet());
-
+		verify(authenticationHolderRepository).save(any(AuthenticationHolderEntity.class));
+		verify(scopeService, atLeastOnce()).removeReservedScopes(anySet());
 	}
 
 	@Test(expected = InvalidTokenException.class)
 	public void refreshAccessToken_noRefreshToken() {
-
-		Mockito.when(tokenRepository.getRefreshTokenByValue(Matchers.anyString())).thenReturn(null);
+		when(tokenRepository.getRefreshTokenByValue(anyString())).thenReturn(null);
 
 		service.refreshAccessToken(refreshTokenValue, tokenRequest);
 	}
 
 	@Test(expected = InvalidClientException.class)
 	public void refreshAccessToken_notAllowRefresh() {
-
-		Mockito.when(client.isAllowRefresh()).thenReturn(false);
+		when(client.isAllowRefresh()).thenReturn(false);
 
 		service.refreshAccessToken(refreshTokenValue, tokenRequest);
 	}
 
 	@Test(expected = InvalidClientException.class)
 	public void refreshAccessToken_clientMismatch() {
-
 		tokenRequest = new TokenRequest(null, badClientId, null, null);
 
 		service.refreshAccessToken(refreshTokenValue, tokenRequest);
@@ -386,96 +375,89 @@ public class TestDefaultOAuth2ProviderTokenService {
 
 	@Test(expected = InvalidTokenException.class)
 	public void refreshAccessToken_expired() {
-
-		Mockito.when(refreshToken.isExpired()).thenReturn(true);
+		when(refreshToken.isExpired()).thenReturn(true);
 
 		service.refreshAccessToken(refreshTokenValue, tokenRequest);
 	}
 
 	@Test
 	public void refreshAccessToken_verifyAcessToken() {
-
 		OAuth2AccessTokenEntity token = service.refreshAccessToken(refreshTokenValue, tokenRequest);
 
-		Mockito.verify(tokenRepository).clearAccessTokensForRefreshToken(refreshToken);
+		verify(tokenRepository).clearAccessTokensForRefreshToken(refreshToken);
 
 		assertThat(token.getClient(), equalTo(client));
 		assertThat(token.getRefreshToken(), equalTo(refreshToken));
 		assertThat(token.getAuthenticationHolder(), equalTo(storedAuthHolder));
 
-		Mockito.verify(tokenEnhancer).enhance(token, storedAuthentication);
-		Mockito.verify(tokenRepository).saveAccessToken(token);
-		Mockito.verify(scopeService, Mockito.atLeastOnce()).removeReservedScopes(Matchers.anySet());
+		verify(tokenEnhancer).enhance(token, storedAuthentication);
+		verify(tokenRepository).saveAccessToken(token);
+		verify(scopeService, atLeastOnce()).removeReservedScopes(anySet());
 
 	}
 
 	@Test
 	public void refreshAccessToken_rotateRefreshToken() {
-
 		when(client.isReuseRefreshToken()).thenReturn(false);
 
 		OAuth2AccessTokenEntity token = service.refreshAccessToken(refreshTokenValue, tokenRequest);
 
-		Mockito.verify(tokenRepository).clearAccessTokensForRefreshToken(refreshToken);
+		verify(tokenRepository).clearAccessTokensForRefreshToken(refreshToken);
 
 		assertThat(token.getClient(), equalTo(client));
 		assertThat(token.getRefreshToken(), not(equalTo(refreshToken)));
 		assertThat(token.getAuthenticationHolder(), equalTo(storedAuthHolder));
 
-		Mockito.verify(tokenEnhancer).enhance(token, storedAuthentication);
-		Mockito.verify(tokenRepository).saveAccessToken(token);
-		Mockito.verify(tokenRepository).removeRefreshToken(refreshToken);
-		Mockito.verify(scopeService, Mockito.atLeastOnce()).removeReservedScopes(Matchers.anySet());
+		verify(tokenEnhancer).enhance(token, storedAuthentication);
+		verify(tokenRepository).saveAccessToken(token);
+		verify(tokenRepository).removeRefreshToken(refreshToken);
+		verify(scopeService, atLeastOnce()).removeReservedScopes(anySet());
 
 	}
 
 	@Test
 	public void refreshAccessToken_keepAccessTokens() {
-
 		when(client.isClearAccessTokensOnRefresh()).thenReturn(false);
 
 		OAuth2AccessTokenEntity token = service.refreshAccessToken(refreshTokenValue, tokenRequest);
 
-		Mockito.verify(tokenRepository, never()).clearAccessTokensForRefreshToken(refreshToken);
+		verify(tokenRepository, never()).clearAccessTokensForRefreshToken(refreshToken);
 
 		assertThat(token.getClient(), equalTo(client));
 		assertThat(token.getRefreshToken(), equalTo(refreshToken));
 		assertThat(token.getAuthenticationHolder(), equalTo(storedAuthHolder));
 
-		Mockito.verify(tokenEnhancer).enhance(token, storedAuthentication);
-		Mockito.verify(tokenRepository).saveAccessToken(token);
-		Mockito.verify(scopeService, Mockito.atLeastOnce()).removeReservedScopes(Matchers.anySet());
+		verify(tokenEnhancer).enhance(token, storedAuthentication);
+		verify(tokenRepository).saveAccessToken(token);
+		verify(scopeService, atLeastOnce()).removeReservedScopes(anySet());
 
 	}
 
 	@Test
 	public void refreshAccessToken_requestingSameScope() {
-
 		OAuth2AccessTokenEntity token = service.refreshAccessToken(refreshTokenValue, tokenRequest);
 
-		Mockito.verify(scopeService, Mockito.atLeastOnce()).removeReservedScopes(Matchers.anySet());
+		verify(scopeService, atLeastOnce()).removeReservedScopes(anySet());
 
 		assertThat(token.getScope(), equalTo(storedScope));
 	}
 
 	@Test
 	public void refreshAccessToken_requestingLessScope() {
-
-		Set<String> lessScope = Sets.newHashSet("openid", "profile");
+		Set<String> lessScope = newHashSet("openid", "profile");
 
 		tokenRequest.setScope(lessScope);
 
 		OAuth2AccessTokenEntity token = service.refreshAccessToken(refreshTokenValue, tokenRequest);
 
-		Mockito.verify(scopeService, Mockito.atLeastOnce()).removeReservedScopes(Matchers.anySet());
+		verify(scopeService, atLeastOnce()).removeReservedScopes(anySet());
 
 		assertThat(token.getScope(), equalTo(lessScope));
 	}
 
 	@Test(expected = InvalidScopeException.class)
 	public void refreshAccessToken_requestingMoreScope() {
-
-		Set<String> moreScope = Sets.newHashSet(storedScope);
+		Set<String> moreScope = newHashSet(storedScope);
 		moreScope.add("address");
 		moreScope.add("phone");
 
@@ -490,8 +472,7 @@ public class TestDefaultOAuth2ProviderTokenService {
 	 */
 	@Test(expected = InvalidScopeException.class)
 	public void refreshAccessToken_requestingMixedScope() {
-
-		Set<String> mixedScope = Sets.newHashSet("openid", "profile", "address", "phone"); // no email or offline_access
+		Set<String> mixedScope = newHashSet("openid", "profile", "address", "phone"); // no email or offline_access
 
 		tokenRequest.setScope(mixedScope);
 
@@ -500,26 +481,24 @@ public class TestDefaultOAuth2ProviderTokenService {
 
 	@Test
 	public void refreshAccessToken_requestingEmptyScope() {
-
-		Set<String> emptyScope = Sets.newHashSet();
+		Set<String> emptyScope = newHashSet();
 
 		tokenRequest.setScope(emptyScope);
 
 		OAuth2AccessTokenEntity token = service.refreshAccessToken(refreshTokenValue, tokenRequest);
 
-		Mockito.verify(scopeService, Mockito.atLeastOnce()).removeReservedScopes(Matchers.anySet());
+		verify(scopeService, atLeastOnce()).removeReservedScopes(anySet());
 
 		assertThat(token.getScope(), equalTo(storedScope));
 	}
 
 	@Test
 	public void refreshAccessToken_requestingNullScope() {
-
 		tokenRequest.setScope(null);
 
 		OAuth2AccessTokenEntity token = service.refreshAccessToken(refreshTokenValue, tokenRequest);
 
-		Mockito.verify(scopeService, Mockito.atLeastOnce()).removeReservedScopes(Matchers.anySet());
+		verify(scopeService, atLeastOnce()).removeReservedScopes(anySet());
 
 		assertThat(token.getScope(), equalTo(storedScope));
 
@@ -530,10 +509,9 @@ public class TestDefaultOAuth2ProviderTokenService {
 	 */
 	@Test
 	public void refreshAccessToken_expiration() {
-
 		Integer accessTokenValiditySeconds = 3600;
 
-		Mockito.when(client.getAccessTokenValiditySeconds()).thenReturn(accessTokenValiditySeconds);
+		when(client.getAccessTokenValiditySeconds()).thenReturn(accessTokenValiditySeconds);
 
 		long start = System.currentTimeMillis();
 		OAuth2AccessTokenEntity token = service.refreshAccessToken(refreshTokenValue, tokenRequest);
@@ -543,14 +521,14 @@ public class TestDefaultOAuth2ProviderTokenService {
 		Date lowerBoundAccessTokens = new Date(start + (accessTokenValiditySeconds * 1000L) - DELTA);
 		Date upperBoundAccessTokens = new Date(end + (accessTokenValiditySeconds * 1000L) + DELTA);
 
-		Mockito.verify(scopeService, Mockito.atLeastOnce()).removeReservedScopes(Matchers.anySet());
+		verify(scopeService, atLeastOnce()).removeReservedScopes(anySet());
 
 		assertTrue(token.getExpiration().after(lowerBoundAccessTokens) && token.getExpiration().before(upperBoundAccessTokens));
 	}
 	
 	@Test
 	public void getAllAccessTokensForUser(){
-		Mockito.when(tokenRepository.getAccessTokensByUserName(userName)).thenReturn(newHashSet(accessToken));
+		when(tokenRepository.getAccessTokensByUserName(userName)).thenReturn(newHashSet(accessToken));
 		
 		Set<OAuth2AccessTokenEntity> tokens = service.getAllAccessTokensForUser(userName);
 		assertEquals(1, tokens.size());
@@ -559,7 +537,7 @@ public class TestDefaultOAuth2ProviderTokenService {
 	
 	@Test
 	public void getAllRefreshTokensForUser(){
-		Mockito.when(tokenRepository.getRefreshTokensByUserName(userName)).thenReturn(newHashSet(refreshToken));
+		when(tokenRepository.getRefreshTokensByUserName(userName)).thenReturn(newHashSet(refreshToken));
 		
 		Set<OAuth2RefreshTokenEntity> tokens = service.getAllRefreshTokensForUser(userName);
 		assertEquals(1, tokens.size());

--- a/openid-connect-server/src/test/java/org/mitre/oauth2/service/impl/TestDefaultOAuth2ProviderTokenService.java
+++ b/openid-connect-server/src/test/java/org/mitre/oauth2/service/impl/TestDefaultOAuth2ProviderTokenService.java
@@ -21,6 +21,7 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -52,6 +53,7 @@ import org.springframework.security.oauth2.provider.token.TokenEnhancer;
 
 import com.google.common.collect.Sets;
 
+import static com.google.common.collect.Sets.newHashSet;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
@@ -60,7 +62,8 @@ import static org.hamcrest.CoreMatchers.nullValue;
 
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.when;
-
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -83,7 +86,9 @@ public class TestDefaultOAuth2ProviderTokenService {
 	private String badClientId = "bad_client";
 	private Set<String> scope = Sets.newHashSet("openid", "profile", "email", "offline_access");
 	private OAuth2RefreshTokenEntity refreshToken;
+	private OAuth2AccessTokenEntity accessToken;
 	private String refreshTokenValue = "refresh_token_value";
+	private String userSub = "6a50ac11786d402a9591d3e592ac770f";
 	private TokenRequest tokenRequest;
 
 	// for use when refreshing access tokens
@@ -142,6 +147,8 @@ public class TestDefaultOAuth2ProviderTokenService {
 		Mockito.when(tokenRepository.getRefreshTokenByValue(refreshTokenValue)).thenReturn(refreshToken);
 		Mockito.when(refreshToken.getClient()).thenReturn(client);
 		Mockito.when(refreshToken.isExpired()).thenReturn(false);
+		
+		accessToken = Mockito.mock(OAuth2AccessTokenEntity.class);
 
 		tokenRequest = new TokenRequest(null, clientId, null, null);
 
@@ -542,5 +549,22 @@ public class TestDefaultOAuth2ProviderTokenService {
 
 		assertTrue(token.getExpiration().after(lowerBoundAccessTokens) && token.getExpiration().before(upperBoundAccessTokens));
 	}
-
+	
+	@Test
+	public void getAllAccessTokensForUser(){
+		Mockito.when(tokenRepository.getAccessTokensBySub(userSub)).thenReturn(newHashSet(accessToken));
+		
+		Set<OAuth2AccessTokenEntity> tokens = service.getAllAccessTokensForUser(userSub);
+		assertEquals(1, tokens.size());
+		assertTrue(tokens.contains(accessToken));
+	}
+	
+	@Test
+	public void getAllRefreshTokensForUser(){
+		Mockito.when(tokenRepository.getRefreshTokensBySub(userSub)).thenReturn(newHashSet(refreshToken));
+		
+		Set<OAuth2RefreshTokenEntity> tokens = service.getAllRefreshTokensForUser(userSub);
+		assertEquals(1, tokens.size());
+		assertTrue(tokens.contains(refreshToken));
+	}
 }


### PR DESCRIPTION
- In our environment, we don't delete users from db, we just mark them deleted and when this happens we need to delete the access and refresh tokens from the user
- There already was a method in DefaultOAuth2ProviderTokenService for getting the tokens for a user, but that reads all the tokens from database and loops through them to find the correct tokens, in our case the result from the query would be too big
- I created jpa queries to fetch the tokens by user name / sub and changed the implementation of DefaultOAuth2ProviderTokenService to use these new methods
- I didn't find a way to write tests for the repository from the existing unit tests but I did test it manually
- I also did some clean up in the classes I modified