### PR TITLE
"Unable to load locale" log should not be ERROR level 

### DIFF
--- a/openid-connect-server/src/main/java/org/mitre/openid/connect/config/JsonMessageSource.java
+++ b/openid-connect-server/src/main/java/org/mitre/openid/connect/config/JsonMessageSource.java
@@ -16,18 +16,6 @@
 
 package org.mitre.openid.connect.config;
 
-import com.google.common.base.Splitter;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonIOException;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
-import com.google.gson.JsonSyntaxException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.support.AbstractMessageSource;
-import org.springframework.core.io.Resource;
-
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -39,6 +27,19 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.support.AbstractMessageSource;
+import org.springframework.core.io.Resource;
+
+import com.google.common.base.Splitter;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonIOException;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonSyntaxException;
 
 /**
  * @author jricher
@@ -85,6 +86,9 @@ public class JsonMessageSource extends AbstractMessageSource {
 
 	/**
 	 * Get a value from the set of maps, taking the first match in order
+	 * @param code
+	 * @param langs
+	 * @return
 	 */
 	private String getValue(String code, List<JsonObject> langs) {
 		if (langs == null || langs.isEmpty()) {
@@ -106,6 +110,9 @@ public class JsonMessageSource extends AbstractMessageSource {
 
 	/**
 	 * Get a value from a single map
+	 * @param code
+	 * @param lang
+	 * @return
 	 */
 	private String getValue(String code, JsonObject lang) {
 
@@ -144,7 +151,6 @@ public class JsonMessageSource extends AbstractMessageSource {
 		}
 
 		return value;
-
 	}
 
 	/**
@@ -186,7 +192,6 @@ public class JsonMessageSource extends AbstractMessageSource {
 		}
 
 		return languageMaps.get(locale);
-
 	}
 
 	/**

--- a/openid-connect-server/src/main/java/org/mitre/openid/connect/config/JsonMessageSource.java
+++ b/openid-connect-server/src/main/java/org/mitre/openid/connect/config/JsonMessageSource.java
@@ -16,18 +16,6 @@
 
 package org.mitre.openid.connect.config;
 
-import com.google.common.base.Splitter;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonIOException;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
-import com.google.gson.JsonSyntaxException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.support.AbstractMessageSource;
-import org.springframework.core.io.Resource;
-
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -39,6 +27,19 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.support.AbstractMessageSource;
+import org.springframework.core.io.Resource;
+
+import com.google.common.base.Splitter;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonIOException;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonSyntaxException;
 
 /**
  * @author jricher
@@ -81,6 +82,9 @@ public class JsonMessageSource extends AbstractMessageSource {
 
 	/**
 	 * Get a value from the set of maps, taking the first match in order
+	 * @param code
+	 * @param langs
+	 * @return
 	 */
 	private String getValue(String code, List<JsonObject> langs) {
 		if (langs == null || langs.isEmpty()) {
@@ -102,6 +106,9 @@ public class JsonMessageSource extends AbstractMessageSource {
 
 	/**
 	 * Get a value from a single map
+	 * @param code
+	 * @param lang
+	 * @return
 	 */
 	private String getValue(String code, JsonObject lang) {
 

--- a/openid-connect-server/src/main/java/org/mitre/openid/connect/config/JsonMessageSource.java
+++ b/openid-connect-server/src/main/java/org/mitre/openid/connect/config/JsonMessageSource.java
@@ -16,6 +16,18 @@
 
 package org.mitre.openid.connect.config;
 
+import com.google.common.base.Splitter;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonIOException;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonSyntaxException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.support.AbstractMessageSource;
+import org.springframework.core.io.Resource;
+
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -27,19 +39,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.support.AbstractMessageSource;
-import org.springframework.core.io.Resource;
-
-import com.google.common.base.Splitter;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonIOException;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
-import com.google.gson.JsonSyntaxException;
 
 /**
  * @author jricher
@@ -54,12 +53,8 @@ public class JsonMessageSource extends AbstractMessageSource {
 
 	private Map<Locale, List<JsonObject>> languageMaps = new HashMap<>();
 
-	private ConfigurationPropertiesBean config;
-
 	@Autowired
-	public JsonMessageSource(ConfigurationPropertiesBean config) {
-		this.config = config;
-	}
+	private ConfigurationPropertiesBean config;
 
 	@Override
 	protected MessageFormat resolveCode(String code, Locale locale) {
@@ -86,9 +81,6 @@ public class JsonMessageSource extends AbstractMessageSource {
 
 	/**
 	 * Get a value from the set of maps, taking the first match in order
-	 * @param code
-	 * @param langs
-	 * @return
 	 */
 	private String getValue(String code, List<JsonObject> langs) {
 		if (langs == null || langs.isEmpty()) {
@@ -110,9 +102,6 @@ public class JsonMessageSource extends AbstractMessageSource {
 
 	/**
 	 * Get a value from a single map
-	 * @param code
-	 * @param lang
-	 * @return
 	 */
 	private String getValue(String code, JsonObject lang) {
 
@@ -157,7 +146,7 @@ public class JsonMessageSource extends AbstractMessageSource {
 	 * @param locale
 	 * @return
 	 */
-	List<JsonObject> getLanguageMap(Locale locale) {
+	private List<JsonObject> getLanguageMap(Locale locale) {
 
 		if (!languageMaps.containsKey(locale)) {
 			try {

--- a/openid-connect-server/src/test/java/org/mitre/openid/connect/config/TestJsonMessageSource.java
+++ b/openid-connect-server/src/test/java/org/mitre/openid/connect/config/TestJsonMessageSource.java
@@ -1,22 +1,28 @@
 package org.mitre.openid.connect.config;
 
-import com.google.gson.JsonObject;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Spy;
+import org.mockito.runners.MockitoJUnitRunner;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 
 import java.text.MessageFormat;
-import java.util.List;
 import java.util.Locale;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
+@RunWith(MockitoJUnitRunner.class)
 public class TestJsonMessageSource {
 
+	@InjectMocks
 	private JsonMessageSource jsonMessageSource;
+
+	@Spy
+	private ConfigurationPropertiesBean config;
 
 	private Locale localeThatHasAFile = new Locale("en");
 
@@ -24,24 +30,9 @@ public class TestJsonMessageSource {
 
 	@Before
 	public void setup() {
-		ConfigurationPropertiesBean config = new ConfigurationPropertiesBean();
-		jsonMessageSource = new JsonMessageSource(config);
-
 		//test message files are located in test/resources/js/locale/
 		Resource resource = new ClassPathResource("/resources/js/locale/");
 		jsonMessageSource.setBaseDirectory(resource);
-	}
-
-	@Test
-	public void verifyWhenLocaleExists_languageMapIsLoaded() {
-		List<JsonObject> languageMap = jsonMessageSource.getLanguageMap(localeThatHasAFile);
-		assertNotNull(languageMap);
-	}
-
-	@Test
-	public void verifyWhenLocaleDoesNotExist_languageMapIsNotLoaded() {
-		List<JsonObject> languageMap = jsonMessageSource.getLanguageMap(localeThatDoesNotHaveAFile);
-		assertNull(languageMap);
 	}
 
 	@Test

--- a/openid-connect-server/src/test/java/org/mitre/openid/connect/config/TestJsonMessageSource.java
+++ b/openid-connect-server/src/test/java/org/mitre/openid/connect/config/TestJsonMessageSource.java
@@ -1,0 +1,59 @@
+package org.mitre.openid.connect.config;
+
+import com.google.gson.JsonObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+
+import java.text.MessageFormat;
+import java.util.List;
+import java.util.Locale;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public class TestJsonMessageSource {
+
+	private JsonMessageSource jsonMessageSource;
+
+	private Locale localeThatHasAFile = new Locale("en");
+
+	private Locale localeThatDoesNotHaveAFile = new Locale("xx");
+
+	@Before
+	public void setup() {
+		ConfigurationPropertiesBean config = new ConfigurationPropertiesBean();
+		jsonMessageSource = new JsonMessageSource(config);
+
+		//test message files are located in test/resources/js/locale/
+		Resource resource = new ClassPathResource("/resources/js/locale/");
+		jsonMessageSource.setBaseDirectory(resource);
+	}
+
+	@Test
+	public void verifyWhenLocaleExists_languageMapIsLoaded() {
+		List<JsonObject> languageMap = jsonMessageSource.getLanguageMap(localeThatHasAFile);
+		assertNotNull(languageMap);
+	}
+
+	@Test
+	public void verifyWhenLocaleDoesNotExist_languageMapIsNotLoaded() {
+		List<JsonObject> languageMap = jsonMessageSource.getLanguageMap(localeThatDoesNotHaveAFile);
+		assertNull(languageMap);
+	}
+
+	@Test
+	public void verifyWhenLocaleExists_canResolveCode() {
+		MessageFormat mf = jsonMessageSource.resolveCode("testAttribute", localeThatHasAFile);
+		assertEquals(mf.getLocale().getLanguage(), "en");
+		assertEquals(mf.toPattern(), "testValue");
+	}
+
+	@Test
+	public void verifyWhenLocaleDoesNotExist_cannotResolveCode() {
+		MessageFormat mf = jsonMessageSource.resolveCode("test", localeThatDoesNotHaveAFile);
+		assertNull(mf);
+	}
+}

--- a/openid-connect-server/src/test/resources/resources/js/locale/en/messages.json
+++ b/openid-connect-server/src/test/resources/resources/js/locale/en/messages.json
@@ -1,0 +1,3 @@
+{
+    "testAttribute": "testValue"
+}


### PR DESCRIPTION
This is to resolve issue #1384 

If a locale message file is not found, it should now populate the `languageMap` with a null value and not try to load it every single time it gets requested. I also changed the resulting log message to INFO level instead of ERROR.