### PR TITLE
Update admin.js

### DIFF
--- a/openid-connect-server-webapp/src/main/webapp/resources/js/admin.js
+++ b/openid-connect-server-webapp/src/main/webapp/resources/js/admin.js
@@ -137,7 +137,8 @@ var ListWidgetChildView = Backbone.View.extend({
 
 			var _self = this;
 
-			$(this.el).click(function(event) {
+			// added span to enable checkbox also
+			$(this.el).find('span').click(function(event) {
 				event.preventDefault();
 				$('.item-short', _self.el).hide();
 				$('.item-full', _self.el).show();


### PR DESCRIPTION
Allow scope names longer than 30 characters to be checked in the client scope list.

Fixes Issue #1387