### PR TITLE
Corrected Oracle create script

### DIFF
--- a/openid-connect-server-webapp/src/main/resources/db/oracle/create_db-user
+++ b/openid-connect-server-webapp/src/main/resources/db/oracle/create_db-user
@@ -1,0 +1,15 @@
+drop user oauth cascade;
+drop tablespace data_ts INCLUDING CONTENTS AND DATAFILES;
+drop tablespace temp_ts INCLUDING CONTENTS AND DATAFILES;
+CREATE TABLESPACE data_ts DATAFILE 'data_ts.dat' SIZE 40M ONLINE;
+CREATE TEMPORARY TABLESPACE temp_ts TEMPFILE 'temp_ts.dbf' SIZE 5M AUTOEXTEND ON;
+create user oauth identified by test DEFAULT TABLESPACE data_ts QUOTA 500K ON data_ts TEMPORARY TABLESPACE temp_ts;
+GRANT CONNECT TO oauth;
+GRANT UNLIMITED TABLESPACE TO oauth;
+grant create session to oauth;
+grant create table to oauth;
+GRANT CREATE TABLESPACE TO oauth;
+GRANT CREATE VIEW TO oauth;
+GRANT CREATE ANY INDEX TO oauth;
+GRANT CREATE SEQUENCE TO oauth;
+GRANT CREATE SYNONYM TO oauth;


### PR DESCRIPTION
The oracle create script doesn't properly cleanup after itself if re-run.