### PR TITLE
Fix slow query for unused AuthenticationHolder entities (Postgres)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 Unreleased:
+- Authorization codes are now longer
+- Client/RS can parse the "sub" and "user_id" claims in introspection response
+- Database-direct queries for fetching tokens by user (optimization)
+- Device flow supports verification_uri_complete (must be turned on)
+- Long scopes display properly and are still checkable
+- Language system remebers when it can't find a file and stops throwing so many errors
+- Index added for refresh tokens
+- Updated to Spring Security 4.2.4
 
 *1.3.2:
 - Added changelog

--- a/openid-connect-common/src/main/java/org/mitre/oauth2/model/AuthenticationHolderEntity.java
+++ b/openid-connect-common/src/main/java/org/mitre/oauth2/model/AuthenticationHolderEntity.java
@@ -54,9 +54,9 @@ import org.springframework.security.oauth2.provider.OAuth2Request;
 @NamedQueries ({
 	@NamedQuery(name = AuthenticationHolderEntity.QUERY_ALL, query = "select a from AuthenticationHolderEntity a"),
 	@NamedQuery(name = AuthenticationHolderEntity.QUERY_GET_UNUSED, query = "select a from AuthenticationHolderEntity a where " +
-			"a.id not in (select t.authenticationHolder.id from OAuth2AccessTokenEntity t) and " +
-			"a.id not in (select r.authenticationHolder.id from OAuth2RefreshTokenEntity r) and " +
-			"a.id not in (select c.authenticationHolder.id from AuthorizationCodeEntity c)")
+			"not exists (select t.authenticationHolder.id from OAuth2AccessTokenEntity t where t.authenticationHolder.id = a.id) and " +
+			"not exists (select r.authenticationHolder.id from OAuth2RefreshTokenEntity r where r.authenticationHolder.id = a.id) and " +
+			"not exists (select c.authenticationHolder.id from AuthorizationCodeEntity c where c.authenticationHolder.id = a.id)")
 })
 public class AuthenticationHolderEntity {
 

--- a/openid-connect-server/src/test/java/org/mitre/oauth2/service/impl/TestDefaultOAuth2ProviderTokenService.java
+++ b/openid-connect-server/src/test/java/org/mitre/oauth2/service/impl/TestDefaultOAuth2ProviderTokenService.java
@@ -42,6 +42,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.security.oauth2.common.exceptions.InvalidClientException;
+import org.springframework.security.oauth2.common.exceptions.InvalidGrantException;
 import org.springframework.security.oauth2.common.exceptions.InvalidScopeException;
 import org.springframework.security.oauth2.common.exceptions.InvalidTokenException;
 import org.springframework.security.oauth2.provider.OAuth2Authentication;
@@ -147,7 +148,7 @@ public class TestDefaultOAuth2ProviderTokenService {
 		when(tokenRepository.getRefreshTokenByValue(refreshTokenValue)).thenReturn(refreshToken);
 		when(refreshToken.getClient()).thenReturn(client);
 		when(refreshToken.isExpired()).thenReturn(false);
-		
+
 		accessToken = Mockito.mock(OAuth2AccessTokenEntity.class);
 
 		tokenRequest = new TokenRequest(null, clientId, null, null);
@@ -352,7 +353,7 @@ public class TestDefaultOAuth2ProviderTokenService {
 		verify(scopeService, atLeastOnce()).removeReservedScopes(anySet());
 	}
 
-	@Test(expected = InvalidTokenException.class)
+	@Test(expected = InvalidGrantException.class)
 	public void refreshAccessToken_noRefreshToken() {
 		when(tokenRepository.getRefreshTokenByValue(anyString())).thenReturn(null);
 
@@ -366,14 +367,14 @@ public class TestDefaultOAuth2ProviderTokenService {
 		service.refreshAccessToken(refreshTokenValue, tokenRequest);
 	}
 
-	@Test(expected = InvalidClientException.class)
+	@Test(expected = InvalidGrantException.class)
 	public void refreshAccessToken_clientMismatch() {
 		tokenRequest = new TokenRequest(null, badClientId, null, null);
 
 		service.refreshAccessToken(refreshTokenValue, tokenRequest);
 	}
 
-	@Test(expected = InvalidTokenException.class)
+	@Test(expected = InvalidGrantException.class)
 	public void refreshAccessToken_expired() {
 		when(refreshToken.isExpired()).thenReturn(true);
 
@@ -525,20 +526,20 @@ public class TestDefaultOAuth2ProviderTokenService {
 
 		assertTrue(token.getExpiration().after(lowerBoundAccessTokens) && token.getExpiration().before(upperBoundAccessTokens));
 	}
-	
+
 	@Test
 	public void getAllAccessTokensForUser(){
 		when(tokenRepository.getAccessTokensByUserName(userName)).thenReturn(newHashSet(accessToken));
-		
+
 		Set<OAuth2AccessTokenEntity> tokens = service.getAllAccessTokensForUser(userName);
 		assertEquals(1, tokens.size());
 		assertTrue(tokens.contains(accessToken));
 	}
-	
+
 	@Test
 	public void getAllRefreshTokensForUser(){
 		when(tokenRepository.getRefreshTokensByUserName(userName)).thenReturn(newHashSet(refreshToken));
-		
+
 		Set<OAuth2RefreshTokenEntity> tokens = service.getAllRefreshTokensForUser(userName);
 		assertEquals(1, tokens.size());
 		assertTrue(tokens.contains(refreshToken));


### PR DESCRIPTION
The named query for unused AuthenticationHolder entities uses "not in" selects resulting in slow query times (>30 min) on Postgres with a large amount of access token generations. Using "not exists" queries instead fixes this behavior.
Additionally the device code dependency is now checked as well to be sure that the AuthenticationHolder is not longer referenced.