### PR TITLE
Optimize the scope matching by eliminating calls to DB.

### DIFF
--- a/openid-connect-server/src/main/java/org/mitre/oauth2/service/impl/DefaultSystemScopeService.java
+++ b/openid-connect-server/src/main/java/org/mitre/oauth2/service/impl/DefaultSystemScopeService.java
@@ -171,21 +171,14 @@ public class DefaultSystemScopeService implements SystemScopeService {
 	@Override
 	public boolean scopesMatch(Set<String> expected, Set<String> actual) {
 
-		Set<SystemScope> ex = fromStrings(expected);
-		Set<SystemScope> act = fromStrings(actual);
-
-		for (SystemScope actScope : act) {
-			// first check to see if there's an exact match
-			if (!ex.contains(actScope)) {
+		for (String actScopeName : actual) {
+			if (! expected.contains(actScopeName)) {
 				return false;
-			} else {
-				// if we did find an exact match, we need to check the rest
 			}
 		}
 
 		// if we got all the way down here, the setup passed
 		return true;
-
 	}
 
 	@Override

--- a/openid-connect-server/src/test/java/org/mitre/oauth2/service/impl/TestDefaultSystemScopeService.java
+++ b/openid-connect-server/src/test/java/org/mitre/oauth2/service/impl/TestDefaultSystemScopeService.java
@@ -175,6 +175,7 @@ public class TestDefaultSystemScopeService {
 		Set<String> actualGood = Sets.newHashSet("foo", "baz", "bar");
 		Set<String> actualGood2 = Sets.newHashSet("foo", "bar");
 		Set<String> actualBad = Sets.newHashSet("foo", "bob", "bar");
+		Set<String> noScopes = Sets.newHashSet();
 
 		// same scopes, different order
 		assertThat(service.scopesMatch(expected, actualGood), is(true));
@@ -184,6 +185,9 @@ public class TestDefaultSystemScopeService {
 
 		// extra scope (fail)
 		assertThat(service.scopesMatch(expected, actualBad), is(false));
+
+		// no  scopes
+		assertThat(service.scopesMatch(noScopes, noScopes), is(true));
 	}
 
 }


### PR DESCRIPTION
The optimization is based on eliminating db calls that get system scopes by their names and for each one found it creates an instance of SystemScope  object for comparison.