### PR TITLE
#1435: Update guava dependency to latest version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -564,7 +564,7 @@
 			<dependency>
 				<groupId>com.google.guava</groupId>
 				<artifactId>guava</artifactId>
-				<version>21.0</version>
+				<version>27.0-jre</version>
 			</dependency>
 			<dependency>
 				<groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
Update the guava dependency to the latest version.  This fixes #1435. This change does require java 8.