### PR TITLE
added refresh_token into grant_types_supported

### DIFF
--- a/openid-connect-server/src/main/java/org/mitre/discovery/web/DiscoveryEndpoint.java
+++ b/openid-connect-server/src/main/java/org/mitre/discovery/web/DiscoveryEndpoint.java
@@ -304,7 +304,7 @@ public class DiscoveryEndpoint {
 				JWSAlgorithm.ES256, JWSAlgorithm.ES384, JWSAlgorithm.ES512,
 				JWSAlgorithm.PS256, JWSAlgorithm.PS384, JWSAlgorithm.PS512,
 				Algorithm.NONE);
-		ArrayList<String> grantTypes = Lists.newArrayList("authorization_code", "implicit", "urn:ietf:params:oauth:grant-type:jwt-bearer", "client_credentials", "urn:ietf:params:oauth:grant_type:redelegate", "urn:ietf:params:oauth:grant-type:device_code");
+		ArrayList<String> grantTypes = Lists.newArrayList("authorization_code", "implicit", "urn:ietf:params:oauth:grant-type:jwt-bearer", "client_credentials", "urn:ietf:params:oauth:grant_type:redelegate", "urn:ietf:params:oauth:grant-type:device_code","refresh_token");
 
 		Map<String, Object> m = new HashMap<>();
 		m.put("issuer", config.getIssuer());


### PR DESCRIPTION
Some client libraries refuse to use refresh_tokens with MITREid because its support is not declared in the grant_types_supported list in the /.well-known/openid-configuration metadata. This commit adds the value refresh_token to the grant_types_supported list.