### PR TITLE
updated dependencies patchlevels to prevent CVE-2017-17485

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -365,7 +365,7 @@
 			<dependency>
 				<groupId>org.springframework</groupId>
 				<artifactId>spring-framework-bom</artifactId>
-				<version>4.3.7.RELEASE</version>
+				<version>4.3.22.RELEASE</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
@@ -374,19 +374,19 @@
 			<dependency>
 				<groupId>com.fasterxml.jackson.core</groupId>
 				<artifactId>jackson-databind</artifactId>
-				<version>2.9.0.pr2</version>
+				<version>2.9.8</version>
 			</dependency>
 			<dependency>
 				<groupId>com.fasterxml.jackson.core</groupId>
 				<artifactId>jackson-annotations</artifactId>
-				<version>2.9.0.pr2</version>
+				<version>2.9.8</version>
 			</dependency>
 
 			<!-- Spring Security -->
 			<dependency>
 				<groupId>org.springframework.security</groupId>
 				<artifactId>spring-security-bom</artifactId>
-				<version>4.2.4.RELEASE</version>
+				<version>4.2.11.RELEASE</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>


### PR DESCRIPTION
The jackson-databind library is known to have arbitrary code execution vulnerability in the version 2.9.0 used by MITREid, see https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-17485
This commit updates the library and some Spring libraries to their latest patchlevels.