### PR TITLE
bumped oauth2 dependency to 2.1.4 because of CVE-2019-3778

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -393,7 +393,7 @@
 			<dependency>
 				<groupId>org.springframework.security.oauth</groupId>
 				<artifactId>spring-security-oauth2</artifactId>
-				<version>2.1.0.RELEASE</version>
+				<version>2.1.4.RELEASE</version>
 			</dependency>
 
 			<!-- Servlet -->


### PR DESCRIPTION
issue #1468