### PR TITLE
fix mistakes in oracle_database_tables.sql

### DIFF
--- a/openid-connect-server-webapp/src/main/resources/db/oracle/oracle_database_tables.sql
+++ b/openid-connect-server-webapp/src/main/resources/db/oracle/oracle_database_tables.sql
@@ -180,9 +180,9 @@ CREATE TABLE client_details (
   initiate_login_uri VARCHAR2(2048),
   clear_access_tokens_on_refresh NUMBER(1) DEFAULT 1 NOT NULL,
   
-  software_statement VARCHAR(4096),
-  software_id VARCHAR(2048),
-  software_statement VARCHAR2(4000),
+  software_statement VARCHAR2(4096),
+  software_id VARCHAR2(2048),
+  software_version VARCHAR2(2048),
 	
   code_challenge_method VARCHAR2(256),
 

--- a/openid-connect-server-webapp/src/main/resources/db/oracle/oracle_database_tables.sql
+++ b/openid-connect-server-webapp/src/main/resources/db/oracle/oracle_database_tables.sql
@@ -93,8 +93,7 @@ CREATE TABLE saved_user_auth (
   id NUMBER(19) NOT NULL PRIMARY KEY,
   name VARCHAR2(1024),
   authenticated NUMBER(1),
-  source_class VARCHAR2(2048),
-
+  source_class VARCHAR2(2048)
   CONSTRAINT authenticated_check CHECK (authenticated in (1,0))
 );
 CREATE SEQUENCE saved_user_auth_seq START WITH 1 INCREMENT BY 1 NOCACHE NOCYCLE;

--- a/openid-connect-server-webapp/src/main/resources/db/oracle/oracle_database_tables.sql
+++ b/openid-connect-server-webapp/src/main/resources/db/oracle/oracle_database_tables.sql
@@ -180,7 +180,7 @@ CREATE TABLE client_details (
   initiate_login_uri VARCHAR2(2048),
   clear_access_tokens_on_refresh NUMBER(1) DEFAULT 1 NOT NULL,
   
-  software_statement VARCHAR2(4096),
+  software_statement VARCHAR2(4000),
   software_id VARCHAR2(2048),
   software_version VARCHAR2(2048),
 	


### PR DESCRIPTION
Fix some little issues in oracle_database_tables.sql wrt the client_details table.
- remove duplicated column "software_statement".
- add column "software_version" as a varchar2 length 2048 (cf. hsql and mysql scripts)
- fix columns "software_statement" and "software_id", should be type "varchar2" not "varchar", length 4000 (maximum allowed by oracle)
- remove dangling comma in "saved_user_auth" table creation