### PR TITLE
Update mysql-connector to 8.0.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -419,7 +419,7 @@
 			<dependency>
 				<groupId>mysql</groupId>
 				<artifactId>mysql-connector-java</artifactId>
-				<version>5.1.42</version>
+				<version>8.0.13</version>
 			</dependency>
 			<dependency>
 				<groupId>org.hsqldb</groupId>


### PR DESCRIPTION
As mentioned in https://github.com/mitreid-connect/OpenID-Connect-Java-Spring-Server/issues/1494 - I need to be able to connect to newer mysql databases, which is not possible given the old version of mysql. 

I built the patched version locally and applied the overlay on it. 

The resulting product runs as required,  now delivering some (cosmetic) warnings on startup. Removing those warnings should required some source changes.

```
Loading class `com.mysql.jdbc.Driver'. This is deprecated. The new driver class is `com.mysql.cj.jdbc.Driver'. The driver is automatically registered via the SPI and manual loading of the driver class is generally unnecessary.
...
[EL Info]: 2019-07-09 09:52:49.384--ServerSession(2141526452)--EclipseLink, version: Eclipse Persistence Services - 2.7.4.v20190115-ad5b7c6b2a
[EL Info]: connection: 2019-07-09 09:52:49.917--ServerSession(2141526452)--/file:/private/var/folders/rq/bwqzcstj45lbsxj83v189jg40000gn/T/jetty-0.0.0.0-8380-openid.war-_openid-any-3436388020107941948.dir/webapp/WEB-INF/lib/openid-connect-common-1.3.4-SNAPSHOT.jar_defaultPersistenceUnit login successful
[EL Info]: 2019-07-09 09:52:49.999--ServerSession(1782136855)--EclipseLink, version: Eclipse Persistence Services - 2.7.4.v20190115-ad5b7c6b2a
WARN : com.zaxxer.hikari.util.DriverDataSource - Registered driver with driverClassName=com.mysql.jdbc.Driver was not found, trying direct instantiation.
[EL Info]: connection: 2019-07-09 09:52:50.158--ServerSession(1782136855)--/bundleresource://60.fwk1403704789/_elexisPersistenceUnit login successful

```