### PR TITLE
Fix error-page for POST,PUT, etc.

### DIFF
--- a/openid-connect-server-webapp/src/main/java/org/mitre/openid/connect/ErrorController.java
+++ b/openid-connect-server-webapp/src/main/java/org/mitre/openid/connect/ErrorController.java
@@ -1,0 +1,27 @@
+package org.mitre.openid.connect;
+
+import javax.servlet.RequestDispatcher;
+import javax.servlet.http.HttpServletRequest;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+public class ErrorController {
+
+	private static final Logger logger = LoggerFactory.getLogger(ErrorController.class);
+
+	@RequestMapping("/errorController")
+	public String handle(HttpServletRequest req) {
+		Throwable errorException = (Throwable) req.getAttribute(RequestDispatcher.ERROR_EXCEPTION);
+		String message = (String) req.getAttribute(RequestDispatcher.ERROR_MESSAGE);
+		String requestUri = (String) req.getAttribute(RequestDispatcher.ERROR_REQUEST_URI);
+
+		logger.error("request {} failed with {}", requestUri, message);
+		logger.error("exception", errorException);
+
+		return "/error";
+	}
+}

--- a/openid-connect-server-webapp/src/main/java/org/mitre/openid/connect/ErrorController.java
+++ b/openid-connect-server-webapp/src/main/java/org/mitre/openid/connect/ErrorController.java
@@ -13,7 +13,7 @@ public class ErrorController {
 
 	private static final Logger logger = LoggerFactory.getLogger(ErrorController.class);
 
-	@RequestMapping("/errorController")
+	@RequestMapping("/error")
 	public String handle(HttpServletRequest req) {
 		Throwable errorException = (Throwable) req.getAttribute(RequestDispatcher.ERROR_EXCEPTION);
 		String message = (String) req.getAttribute(RequestDispatcher.ERROR_MESSAGE);
@@ -22,6 +22,6 @@ public class ErrorController {
 		logger.error("request {} failed with {}", requestUri, message);
 		logger.error("exception", errorException);
 
-		return "/error";
+		return "/error-view";
 	}
 }

--- a/openid-connect-server-webapp/src/main/java/org/mitre/openid/connect/ErrorController.java
+++ b/openid-connect-server-webapp/src/main/java/org/mitre/openid/connect/ErrorController.java
@@ -29,7 +29,7 @@ public class ErrorController {
 	}
 
 	private void processError(HttpServletRequest request) {
-		if (request.getAttribute("error") != null && request.getAttribute("error") instanceof OAuth2Exception) {
+		if (request.getAttribute("error") instanceof OAuth2Exception) {
 			request.setAttribute("errorCode", ((OAuth2Exception)request.getAttribute("error")).getOAuth2ErrorCode());
 			request.setAttribute("message", ((OAuth2Exception)request.getAttribute("error")).getMessage());
 		} else if (request.getAttribute(RequestDispatcher.ERROR_EXCEPTION) != null) {

--- a/openid-connect-server-webapp/src/main/java/org/mitre/openid/connect/ErrorController.java
+++ b/openid-connect-server-webapp/src/main/java/org/mitre/openid/connect/ErrorController.java
@@ -5,6 +5,8 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.oauth2.common.exceptions.OAuth2Exception;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -22,6 +24,26 @@ public class ErrorController {
 		logger.error("request {} failed with {}", requestUri, message);
 		logger.error("exception", errorException);
 
+		processError(req);
 		return "/error-view";
+	}
+
+	private void processError(HttpServletRequest request) {
+		if (request.getAttribute("error") != null && request.getAttribute("error") instanceof OAuth2Exception) {
+			request.setAttribute("errorCode", ((OAuth2Exception)request.getAttribute("error")).getOAuth2ErrorCode());
+			request.setAttribute("message", ((OAuth2Exception)request.getAttribute("error")).getMessage());
+		} else if (request.getAttribute(RequestDispatcher.ERROR_EXCEPTION) != null) {
+			Throwable t = (Throwable)request.getAttribute(RequestDispatcher.ERROR_EXCEPTION);
+			request.setAttribute("errorCode",  t.getClass().getSimpleName() + " (" + request.getAttribute(RequestDispatcher.ERROR_STATUS_CODE) + ")");
+			request.setAttribute("message", t.getMessage());
+		} else if (request.getAttribute(RequestDispatcher.ERROR_STATUS_CODE) != null) {
+			Integer code = (Integer)request.getAttribute(RequestDispatcher.ERROR_STATUS_CODE);
+			HttpStatus status = HttpStatus.valueOf(code);
+			request.setAttribute("errorCode", status.toString() + " " + status.getReasonPhrase());
+			request.setAttribute("message", request.getAttribute(RequestDispatcher.ERROR_MESSAGE));
+		} else {
+			request.setAttribute("errorCode", "Server error");
+			request.setAttribute("message", "See the logs for details");
+		}
 	}
 }

--- a/openid-connect-server-webapp/src/main/webapp/WEB-INF/authz-config.xml
+++ b/openid-connect-server-webapp/src/main/webapp/WEB-INF/authz-config.xml
@@ -55,6 +55,6 @@
 	<bean id="oauthRequestValidator" class="org.mitre.oauth2.token.ScopeServiceAwareOAuth2RequestValidator" />
 
 	<!-- Error page handler. -->
-	<mvc:view-controller path="/error" view-name="error" />
+	<mvc:view-controller path="/errorview" view-name="error-view" />
 
 </beans>

--- a/openid-connect-server-webapp/src/main/webapp/WEB-INF/views/error.jsp
+++ b/openid-connect-server-webapp/src/main/webapp/WEB-INF/views/error.jsp
@@ -4,27 +4,7 @@
 <%@ taglib prefix="o" tagdir="/WEB-INF/tags"%>
 <%@ taglib prefix="spring" uri="http://www.springframework.org/tags"%>
 <%@ taglib prefix="security" uri="http://www.springframework.org/security/tags"%>
-<%@page import="org.springframework.security.oauth2.common.exceptions.OAuth2Exception"%>
-<% 
 
-if (request.getAttribute("error") != null && request.getAttribute("error") instanceof OAuth2Exception) {
-	request.setAttribute("errorCode", ((OAuth2Exception)request.getAttribute("error")).getOAuth2ErrorCode());
-	request.setAttribute("message", ((OAuth2Exception)request.getAttribute("error")).getMessage());
-} else if (request.getAttribute("javax.servlet.error.exception") != null) {
-	Throwable t = (Throwable)request.getAttribute("javax.servlet.error.exception");
-	request.setAttribute("errorCode",  t.getClass().getSimpleName() + " (" + request.getAttribute("javax.servlet.error.status_code") + ")");
-	request.setAttribute("message", t.getMessage());
-} else if (request.getAttribute("javax.servlet.error.status_code") != null) {
-	Integer code = (Integer)request.getAttribute("javax.servlet.error.status_code");
-	HttpStatus status = HttpStatus.valueOf(code);
-	request.setAttribute("errorCode", status.toString() + " " + status.getReasonPhrase());
-	request.setAttribute("message", request.getAttribute("javax.servlet.error.message"));
-} else {
-	request.setAttribute("errorCode", "Server error");
-	request.setAttribute("message", "See the logs for details");
-}
-
-%>
 <spring:message code="error.title" var="title"/>
 <o:header title="${title}" />
 <o:topbar pageName="Error" />
@@ -38,11 +18,9 @@ if (request.getAttribute("error") != null && request.getAttribute("error") insta
 				<p>
 					<spring:message code="error.message"/>
 					<blockquote class="text-error"><b><c:out value="${ message }" /></b></blockquote>
-                </p>
-				
+				</p>
 			</div>
-
 		</div>
 	</div>
 </div>
-<o:footer />
+<o:footer/>

--- a/openid-connect-server-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/openid-connect-server-webapp/src/main/webapp/WEB-INF/web.xml
@@ -71,9 +71,9 @@
 			<trim-directive-whitespaces>true</trim-directive-whitespaces>
 		</jsp-property-group>
 	</jsp-config>
-	
+
 	<error-page>
-		<location>/error</location>
+		<location>/errorController</location>
 	</error-page>
-	
+
 </web-app>

--- a/pom.xml
+++ b/pom.xml
@@ -404,8 +404,8 @@
 			</dependency>
 			<dependency>
 				<groupId>javax.servlet</groupId>
-				<artifactId>servlet-api</artifactId>
-				<version>2.5</version>
+				<artifactId>javax.servlet-api</artifactId>
+				<version>3.0.1</version>
 				<scope>provided</scope>
 			</dependency>
 			<dependency>
@@ -644,7 +644,7 @@
 		</dependency>
 		<dependency>
 			<groupId>javax.servlet</groupId>
-			<artifactId>servlet-api</artifactId>
+			<artifactId>javax.servlet-api</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>javax.servlet.jsp</groupId>


### PR DESCRIPTION
the view controller error in authz-config.xml forwards to the resp. JSP,
but the error page only supports GET method.

Install a real error controller that at least logs all error messages
and then forwards to the view controller, so not handled exceptions for
e.g. POST request can actually be found.