### PR TITLE
SystemScopeService: Optimize SQL access

### DIFF
--- a/openid-connect-common/src/main/java/org/mitre/oauth2/model/SystemScope.java
+++ b/openid-connect-common/src/main/java/org/mitre/oauth2/model/SystemScope.java
@@ -38,11 +38,13 @@ import javax.persistence.Table;
 @Table(name = "system_scope")
 @NamedQueries({
 	@NamedQuery(name = SystemScope.QUERY_ALL, query = "select s from SystemScope s ORDER BY s.id"),
-	@NamedQuery(name = SystemScope.QUERY_BY_VALUE, query = "select s from SystemScope s WHERE s.value = :" + SystemScope.PARAM_VALUE)
+	@NamedQuery(name = SystemScope.QUERY_BY_VALUE, query  = "select s from SystemScope s WHERE s.value = :" + SystemScope.PARAM_VALUE),
+	@NamedQuery(name = SystemScope.QUERY_BY_VALUES, query = "select s from SystemScope s WHERE s.value in :" + SystemScope.PARAM_VALUE)
 })
 public class SystemScope {
 
 	public static final String QUERY_BY_VALUE = "SystemScope.getByValue";
+	public static final String QUERY_BY_VALUES = "SystemScope.getByValues";
 	public static final String QUERY_ALL = "SystemScope.findAll";
 
 	public static final String PARAM_VALUE = "value";

--- a/openid-connect-common/src/main/java/org/mitre/oauth2/repository/SystemScopeRepository.java
+++ b/openid-connect-common/src/main/java/org/mitre/oauth2/repository/SystemScopeRepository.java
@@ -36,6 +36,8 @@ public interface SystemScopeRepository {
 
 	public SystemScope getByValue(String value);
 
+	public Set<SystemScope> getByValues(Set<String> values);
+
 	public void remove(SystemScope scope);
 
 	public SystemScope save(SystemScope scope);

--- a/openid-connect-server/src/main/java/org/mitre/oauth2/repository/impl/JpaSystemScopeRepository.java
+++ b/openid-connect-server/src/main/java/org/mitre/oauth2/repository/impl/JpaSystemScopeRepository.java
@@ -23,6 +23,7 @@ package org.mitre.oauth2.repository.impl;
 import static org.mitre.util.jpa.JpaUtil.getSingleResult;
 import static org.mitre.util.jpa.JpaUtil.saveOrUpdate;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -79,6 +80,10 @@ public class JpaSystemScopeRepository implements SystemScopeRepository {
 
 	@Override
 	public Set<SystemScope> getByValues(Set<String> values) {
+		if(values.isEmpty()) {
+			return Collections.emptySet();
+		}
+
 		TypedQuery<SystemScope> query = em.createNamedQuery(SystemScope.QUERY_BY_VALUES, SystemScope.class);
 		query.setParameter(SystemScope.PARAM_VALUE, values);
 		return new HashSet<>(query.getResultList());

--- a/openid-connect-server/src/main/java/org/mitre/oauth2/repository/impl/JpaSystemScopeRepository.java
+++ b/openid-connect-server/src/main/java/org/mitre/oauth2/repository/impl/JpaSystemScopeRepository.java
@@ -23,6 +23,7 @@ package org.mitre.oauth2.repository.impl;
 import static org.mitre.util.jpa.JpaUtil.getSingleResult;
 import static org.mitre.util.jpa.JpaUtil.saveOrUpdate;
 
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
@@ -74,6 +75,13 @@ public class JpaSystemScopeRepository implements SystemScopeRepository {
 		TypedQuery<SystemScope> query = em.createNamedQuery(SystemScope.QUERY_BY_VALUE, SystemScope.class);
 		query.setParameter(SystemScope.PARAM_VALUE, value);
 		return getSingleResult(query.getResultList());
+	}
+
+	@Override
+	public Set<SystemScope> getByValues(Set<String> values) {
+		TypedQuery<SystemScope> query = em.createNamedQuery(SystemScope.QUERY_BY_VALUES, SystemScope.class);
+		query.setParameter(SystemScope.PARAM_VALUE, values);
+		return new HashSet<>(query.getResultList());
 	}
 
 	/* (non-Javadoc)

--- a/openid-connect-server/src/main/java/org/mitre/oauth2/service/impl/DefaultSystemScopeService.java
+++ b/openid-connect-server/src/main/java/org/mitre/oauth2/service/impl/DefaultSystemScopeService.java
@@ -22,6 +22,7 @@ package org.mitre.oauth2.service.impl;
 
 import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -136,15 +137,15 @@ public class DefaultSystemScopeService implements SystemScopeService {
 		if (scope == null) {
 			return null;
 		} else {
-			Set<String> scopeValues = scope.stream().filter(s -> s != null).collect(Collectors.toSet());
+			Set<String> scopeValues = scope.stream().filter(Objects::nonNull).collect(Collectors.toSet());
 			Set<SystemScope> scopesFromDB = getByValues(scopeValues);
 			Set<String> scopesFromDBValues = scopesFromDB.stream().map(SystemScope::getValue).collect(Collectors.toSet());
-			Set<SystemScope> missingScopesFromDB = scopesFromDB
+			Set<SystemScope> missingScopesFromDB = scopeValues
 					.stream()
-					.map(SystemScope::getValue)
 					.filter(sv -> !scopesFromDBValues.contains(sv))
 					.map(sv -> new SystemScope(sv))
 					.collect(Collectors.toSet());
+
 			Set<SystemScope> allScopes = new HashSet<SystemScope>();
 			allScopes.addAll(scopesFromDB);
 			allScopes.addAll(missingScopesFromDB);


### PR DESCRIPTION
The scopesMatch() method is called for each ApprovedSite in the approval
process and for each ApprovedSite entry all SystemScopes are read by a
single SQL statement.

Optimise this a bit and switch to a List so only one SQL is issued per
ApprovedSite.