### PR TITLE
Fix XSS (CVE-2020-5497)

### DIFF
--- a/openid-connect-common/src/main/java/org/mitre/openid/connect/web/UserInfoInterceptor.java
+++ b/openid-connect-common/src/main/java/org/mitre/openid/connect/web/UserInfoInterceptor.java
@@ -79,8 +79,9 @@ public class UserInfoInterceptor extends HandlerInterceptorAdapter {
 				// if they're logging into this server from a remote OIDC server, pass through their user info
 				OIDCAuthenticationToken oidc = (OIDCAuthenticationToken) auth;
 				if (oidc.getUserInfo() != null) {
+					JsonElement json = gson.fromJson(oidc.getUserInfo().toJson().toString(), JsonElement.class);
 					request.setAttribute("userInfo", oidc.getUserInfo());
-					request.setAttribute("userInfoJson", oidc.getUserInfo().toJson());
+					request.setAttribute("userInfoJson", gson.toJson(json));
 				} else {
 					request.setAttribute("userInfo", null);
 					request.setAttribute("userInfoJson", "null");
@@ -94,8 +95,9 @@ public class UserInfoInterceptor extends HandlerInterceptorAdapter {
 
 					// if we have one, inject it so views can use it
 					if (user != null) {
+						JsonElement json = gson.fromJson(user.toJson().toString(), JsonElement.class);
 						request.setAttribute("userInfo", user);
-						request.setAttribute("userInfoJson", user.toJson());
+						request.setAttribute("userInfoJson", gson.toJson(json));
 					}
 				}
 			}

--- a/openid-connect-server-webapp/src/main/webapp/WEB-INF/tags/topbar.tag
+++ b/openid-connect-server-webapp/src/main/webapp/WEB-INF/tags/topbar.tag
@@ -1,24 +1,25 @@
 <%@attribute name="pageName" required="false"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
+<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions"%>
 <%@ taglib prefix="security" uri="http://www.springframework.org/security/tags"%>
 <%@ taglib prefix="spring" uri="http://www.springframework.org/tags"%>
 <%@ taglib prefix="o" tagdir="/WEB-INF/tags"%>
 <c:choose>
 	<c:when test="${ not empty userInfo.preferredUsername }">
-		<c:set var="shortName" value="${ userInfo.preferredUsername }" />
+		<c:set var="shortName" value="${ fn:escapeXml(userInfo.preferredUsername) }" />
 	</c:when>
 	<c:otherwise>
-		<c:set var="shortName" value="${ userInfo.sub }" />
+		<c:set var="shortName" value="${ fn:escapeXml(userInfo.sub) }" />
 	</c:otherwise>
 </c:choose>
 <c:choose>
 	<c:when test="${ not empty userInfo.name }">
-		<c:set var="longName" value="${ userInfo.name }" />
+		<c:set var="longName" value="${ fn:escapeXml(userInfo.name) }" />
 	</c:when>
 	<c:otherwise>
 		<c:choose>
 			<c:when test="${ not empty userInfo.givenName || not empty userInfo.familyName }">
-				<c:set var="longName" value="${ userInfo.givenName } ${ userInfo.familyName }" />
+				<c:set var="longName" value="${ fn:escapeXml(userInfo.givenName) } ${ fn:escapeXml(userInfo.familyName) }" />
 			</c:when>
 			<c:otherwise>
 				<c:set var="longName" value="${ shortName }" />


### PR DESCRIPTION
Fix for #1521 

#1526 was on the right track - escapeXml works for the instances in topbar.tag because individual values are referenced from **userInfo**:

~~~
						<li class="dropdown">
							<a id="userButton" class="dropdown-toggle" data-toggle="dropdown" href=""><i class="icon-user icon-white"></i> user <span class="caret"></span></a>
							<ul class="dropdown-menu pull-right">
								<li><a href="manage/#user/profile" data-toggle="collapse" data-target=".nav-collapse">Demo &lt;script&gt;alert(1)&lt;/script&gt;User</a></li>
								<li class="divider"></li>
								<li><a href="" data-toggle="collapse" data-target=".nav-collapse" class="logoutLink"><i class="icon-remove"></i> Log out</a></li>
							</ul>
						</li>
	                    
	                    
	                </ul>
	                
	                <!--  use a simplified user button system when collapsed -->
	                <ul class="nav hidden-desktop">
	                    
						<li><a href="manage/#user/profile">Demo &lt;script&gt;alert(1)&lt;/script&gt;User</a></li>
						<li class="divider"></li>
						<li><a href="" class="logoutLink"><i class="icon-remove"></i> Log out</a></li>
	                    
	                    
	                </ul>
~~~

Using escapeXml on **userInfoJson** in header.tag breaks the JSON:

[Reference image](https://user-images.githubusercontent.com/161021/74786699-97804b80-526a-11ea-8938-11d5ba8be0f1.png)

I looked at UseInforInterceptor, so using custom UserInfo will be protected as well.  It's the simplest way I could think of:

* Convert the response from UserInfo.toJson to JsonElement
* Dump the JsonElement with gson

The result is userInfoJson appearing like:

~~~
   	function getUserInfo() {
    		return {"sub":"01921.FLANRJQW","name":"Demo \u003cscript\u003ealert(1)\u003c/script\u003eUser","preferred_username":"user","email":"user@example.com","email_verified":true};
    	}
~~~



