### PR TITLE
Fix Spring Autobinding vulnerability

### DIFF
--- a/openid-connect-server/src/main/java/org/mitre/oauth2/web/OAuthConfirmationController.java
+++ b/openid-connect-server/src/main/java/org/mitre/oauth2/web/OAuthConfirmationController.java
@@ -103,9 +103,9 @@ public class OAuthConfirmationController {
 
 	@PreAuthorize("hasRole('ROLE_USER')")
 	@RequestMapping("/oauth/confirm_access")
-	public String confimAccess(Map<String, Object> model, @ModelAttribute("authorizationRequest") AuthorizationRequest authRequest,
-			Principal p) {
+	public String confirmAccess(Map<String, Object> model, Principal p) {
 
+		AuthorizationRequest authRequest = (AuthorizationRequest) model.get("authorizationRequest");
 		// Check the "prompt" parameter to see if we need to do special processing
 
 		String prompt = (String)authRequest.getExtensions().get(PROMPT);


### PR DESCRIPTION
1. Make authorizationRequest no longer affected by http request parameters due to @ModelAttribute. See http://agrrrdog.blogspot.com/2017/03/autobinding-vulns-and-spring-mvc.html