### PR TITLE
Signing JWT based on the default keyId.  Currently, it signs based on…

### DIFF
--- a/openid-connect-client/src/main/java/org/mitre/openid/connect/client/OIDCAuthenticationFilter.java
+++ b/openid-connect-client/src/main/java/org/mitre/openid/connect/client/OIDCAuthenticationFilter.java
@@ -425,7 +425,10 @@ public class OIDCAuthenticationFilter extends AbstractAuthenticationProcessingFi
 						null, null);
 				SignedJWT jwt = new SignedJWT(header, claimsSet.build());
 
-				signer.signJwt(jwt, alg);
+				if (signer.getDefaultSignerKeyId() != null)
+					signer.signJwt(jwt);
+				else
+					signer.signJwt(jwt, alg);
 
 				form.add("client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer");
 				form.add("client_assertion", jwt.serialize());


### PR DESCRIPTION
This changes looks to see if there is a default key ID defined.  If so, then we should grab the key based on the key ID from the keystore.  However, the current implementation iterates through a list of keys in a jwks keystore looking for the first which has the desired algorithm.  This works if you have a single key which uses that algorithm.  If we would like a rolling key situation this fails and cannot be relied upon.